### PR TITLE
Refactored IHasPreLoadableGlobalStyle to use the IRule interface.

### DIFF
--- a/Demo/BlazorFluentUI.Demo.Shared/Shared/MainLayout.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Shared/MainLayout.razor
@@ -71,9 +71,9 @@
         base.OnInitialized();
     }
 
-    private ICollection<Rule> CreateGlobalCss(ITheme theme)
+    private ICollection<IRule> CreateGlobalCss(ITheme theme)
     {
-        var themeGlobalRules = new HashSet<Rule>();
+        var themeGlobalRules = new HashSet<IRule>();
         if (customTheme)
         {
             // for Firefox

--- a/src/BlazorFluentUI.BFUBaseComponent/BFUComponentBase.cs
+++ b/src/BlazorFluentUI.BFUBaseComponent/BFUComponentBase.cs
@@ -54,7 +54,7 @@ namespace BlazorFluentUI
         {
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", new BFUComponentBase());
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<Rule>>( CreateGlobalCss ));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>( CreateGlobalCss ));
             builder.AddAttribute(3, "ReloadStyle", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<bool>(reloadStyle));
             builder.AddAttribute(4, "ReloadStyleChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck(EventCallback.Factory.Create(this, Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, __value => reloadStyle = __value, reloadStyle))));
             builder.AddAttribute(5, "FixStyle", true);
@@ -145,9 +145,9 @@ namespace BlazorFluentUI
             reloadStyle = true;
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var overallRules = new HashSet<Rule>();
+            var overallRules = new HashSet<IRule>();
             overallRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = "body" },

--- a/src/BlazorFluentUI.BFUBaseComponent/IHasPreloadableGlobalStyle.cs
+++ b/src/BlazorFluentUI.BFUBaseComponent/IHasPreloadableGlobalStyle.cs
@@ -4,6 +4,6 @@ namespace BlazorFluentUI
 {
     public interface IHasPreloadableGlobalStyle
     {
-        ICollection<Rule> CreateGlobalCss(ITheme theme);
+        ICollection<IRule> CreateGlobalCss(ITheme theme);
     }
 }

--- a/src/BlazorFluentUI.BFUButton/BFUActionButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUActionButton.cs
@@ -5,7 +5,7 @@ namespace BlazorFluentUI
 {
     public class BFUActionButton : BFUButtonBase, IHasPreloadableGlobalStyle
     {
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             var rules = CreateBaseGlobalCss(theme);
 
@@ -174,7 +174,7 @@ namespace BlazorFluentUI
         {
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(()=>CreateGlobalCss(Theme)));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(()=>CreateGlobalCss(Theme)));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUButtonBase.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUButtonBase.cs
@@ -178,9 +178,9 @@ namespace BlazorFluentUI
 
         }
 
-        protected ICollection<Rule> CreateBaseGlobalCss(ITheme theme)
+        protected ICollection<IRule> CreateBaseGlobalCss(ITheme theme)
         {
-            var buttonRules = new HashSet<Rule>();
+            var buttonRules = new HashSet<IRule>();
 
             var props = new FocusStyleProps(theme);
             props.Inset = 1;

--- a/src/BlazorFluentUI.BFUButton/BFUCommandBarButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUCommandBarButton.cs
@@ -5,7 +5,7 @@ namespace BlazorFluentUI
 {
     public class BFUCommandBarButton : BFUButtonBase
     {
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
             var rules = CreateBaseGlobalCss(Theme);
 
@@ -221,7 +221,7 @@ namespace BlazorFluentUI
 
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(CreateGlobalCss));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(CreateGlobalCss));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUCommandButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUCommandButton.cs
@@ -5,7 +5,7 @@ namespace BlazorFluentUI
 {
     public class BFUCommandButton : BFUButtonBase, IHasPreloadableGlobalStyle
     {
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             var rules = CreateBaseGlobalCss(theme);
 
@@ -18,7 +18,7 @@ namespace BlazorFluentUI
 
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(()=>CreateGlobalCss(Theme)));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(()=>CreateGlobalCss(Theme)));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUCompoundButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUCompoundButton.cs
@@ -8,7 +8,7 @@ namespace BlazorFluentUI
     {
         [Parameter] public string SecondaryText { get; set; }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
             var rules = CreateBaseGlobalCss(Theme);
 
@@ -141,7 +141,7 @@ namespace BlazorFluentUI
             
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(CreateGlobalCss));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(CreateGlobalCss));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUDefaultButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUDefaultButton.cs
@@ -5,7 +5,7 @@ namespace BlazorFluentUI
 {
     public class BFUDefaultButton : BFUButtonBase, IHasPreloadableGlobalStyle
     {
-        public virtual ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public virtual ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             var rules = CreateBaseGlobalCss(theme);
 
@@ -86,7 +86,7 @@ namespace BlazorFluentUI
         {
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(()=>CreateGlobalCss(Theme)));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(()=>CreateGlobalCss(Theme)));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUIconButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUIconButton.cs
@@ -6,7 +6,7 @@ namespace BlazorFluentUI
     public class BFUIconButton : BFUButtonBase, IHasPreloadableGlobalStyle
     {
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             var rules = CreateBaseGlobalCss(theme);
 
@@ -96,7 +96,7 @@ namespace BlazorFluentUI
         {
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(()=>CreateGlobalCss(Theme)));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(()=>CreateGlobalCss(Theme)));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUMessageBarButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUMessageBarButton.cs
@@ -5,7 +5,7 @@ namespace BlazorFluentUI
 {
     public class BFUMessageBarButton : BFUDefaultButton, IHasPreloadableGlobalStyle
     {
-        public override ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public override ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
 
             var rules = base.CreateGlobalCss(theme);
@@ -32,7 +32,7 @@ namespace BlazorFluentUI
 
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(()=>CreateGlobalCss(Theme)));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(()=>CreateGlobalCss(Theme)));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUButton/BFUPrimaryButton.cs
+++ b/src/BlazorFluentUI.BFUButton/BFUPrimaryButton.cs
@@ -5,7 +5,7 @@ namespace BlazorFluentUI
 {
     public class BFUPrimaryButton : BFUButtonBase, IHasPreloadableGlobalStyle
     {
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             var rules = CreateBaseGlobalCss(theme);
 
@@ -103,7 +103,7 @@ namespace BlazorFluentUI
         {
             builder.OpenComponent<BFUGlobalCS>(0);
             builder.AddAttribute(1, "Component", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Object>(this));
-            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<System.Collections.Generic.ICollection<BlazorFluentUI.Rule>>(()=> CreateGlobalCss(Theme)));
+            builder.AddAttribute(2, "CreateGlobalCss", new System.Func<ICollection<IRule>>(()=> CreateGlobalCss(Theme)));
             builder.AddAttribute(3, "FixStyle", true);
             builder.CloseComponent();
 

--- a/src/BlazorFluentUI.BFUCalendar/BFUCalendar.razor.cs
+++ b/src/BlazorFluentUI.BFUCalendar/BFUCalendar.razor.cs
@@ -204,7 +204,7 @@ namespace BlazorFluentUI
             NavigatedMonthDate = date;
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             return CalendarStyle.GetCalendarStyle(theme);
         }

--- a/src/BlazorFluentUI.BFUCalendar/CalendarStyle.cs
+++ b/src/BlazorFluentUI.BFUCalendar/CalendarStyle.cs
@@ -4,9 +4,9 @@ namespace BlazorFluentUI
 {
     public static class CalendarStyle
     {
-        public static ICollection<Rule> GetCalendarStyle(ITheme theme)
+        public static ICollection<IRule> GetCalendarStyle(ITheme theme)
         {
-            var MyRules = new List<Rule>();
+            var MyRules = new List<IRule>();
 
             MyRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUCallout/BFUCalloutContent.razor.cs
+++ b/src/BlazorFluentUI.BFUCallout/BFUCalloutContent.razor.cs
@@ -794,9 +794,9 @@ namespace BlazorFluentUI
             };
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var calloutGlobalRules = new HashSet<Rule>();
+            var calloutGlobalRules = new HashSet<IRule>();
             calloutGlobalRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-Callout-container" },

--- a/src/BlazorFluentUI.BFUCheck/BFUCheck.razor.cs
+++ b/src/BlazorFluentUI.BFUCheck/BFUCheck.razor.cs
@@ -11,9 +11,9 @@ namespace BlazorFluentUI
         [Parameter]
         public bool UseFastIcons { get; set; }
 
-        protected ICollection<Rule> CreateGlobalCss()
+        protected ICollection<IRule> CreateGlobalCss()
         {
-            var checkRules = new HashSet<Rule>();
+            var checkRules = new HashSet<IRule>();
 
             checkRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUCheckbox/BFUCheckbox.razor.cs
+++ b/src/BlazorFluentUI.BFUCheckbox/BFUCheckbox.razor.cs
@@ -152,9 +152,9 @@ namespace BlazorFluentUI
 
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var checkboxRules = new HashSet<Rule>();
+            var checkboxRules = new HashSet<IRule>();
             // ROOT
             checkboxRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUCommandBar/BFUCommandBar.razor.cs
+++ b/src/BlazorFluentUI.BFUCommandBar/BFUCommandBar.razor.cs
@@ -94,9 +94,9 @@ namespace BlazorFluentUI
             return string.Join(" ", primaryKey, farKey, overflowKey);
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var commandBarRules = new HashSet<Rule>();
+            var commandBarRules = new HashSet<IRule>();
             commandBarRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-CommandBar" },

--- a/src/BlazorFluentUI.BFUComponentStyle/BFUGlobalCS.cs
+++ b/src/BlazorFluentUI.BFUComponentStyle/BFUGlobalCS.cs
@@ -40,7 +40,7 @@ namespace BlazorFluentUI
         /// Function which create CSS-Rules which should be printed in head tag of index.html
         /// </summary>
         [Parameter]
-        public Func<ICollection<Rule>> CreateGlobalCss { get; set; }
+        public Func<ICollection<IRule>> CreateGlobalCss { get; set; }
 
         [Parameter]
         public EventCallback<bool> ReloadStyleChanged { get; set; }

--- a/src/BlazorFluentUI.BFUComponentStyle/Interfaces/IGlobalCSSheet.cs
+++ b/src/BlazorFluentUI.BFUComponentStyle/Interfaces/IGlobalCSSheet.cs
@@ -9,6 +9,6 @@ namespace BlazorFluentUI
         Type ComponentType { get; set; }
         bool IsGlobal { get; set; }
         bool FixStyle { get; set; }
-        Func<ICollection<Rule>> CreateGlobalCss { get; set; }
+        Func<ICollection<IRule>> CreateGlobalCss { get; set; }
     }
 }

--- a/src/BlazorFluentUI.BFUContextualMenu/BFUContextualMenu.razor.cs
+++ b/src/BlazorFluentUI.BFUContextualMenu/BFUContextualMenu.razor.cs
@@ -144,9 +144,9 @@ namespace BlazorFluentUI
         }
 
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var menuRules = new HashSet<Rule>();
+            var menuRules = new HashSet<IRule>();
             // ROOT
             menuRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUDatePicker/BFUDatePicker.razor.cs
+++ b/src/BlazorFluentUI.BFUDatePicker/BFUDatePicker.razor.cs
@@ -347,9 +347,9 @@ namespace BlazorFluentUI
             return DateTime.Compare(minDate, date) > 0 || DateTime.Compare(maxDate, date) < 0;
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var MyRules = new List<Rule>();
+            var MyRules = new List<IRule>();
             #region ms-DatePicker
             MyRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsColumn.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsColumn.razor.cs
@@ -59,9 +59,9 @@ namespace BlazorFluentUI
             Column.OnColumnClick?.Invoke(Column);
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var columnRules = new HashSet<Rule>();
+            var columnRules = new HashSet<IRule>();
 
             // ROOT
             columnRules.Add(new Rule()

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsHeader.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsHeader.razor.cs
@@ -210,9 +210,9 @@ namespace BlazorFluentUI
         }
 
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var headerRules = new System.Collections.Generic.List<Rule>();
+            var headerRules = new List<IRule>();
 
             // ROOT           
             headerRules.Add(new Rule()

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
@@ -107,10 +107,10 @@ namespace BlazorFluentUI
         public static int CellRightPadding = 8;
         public static int CellExtraRightPadding = 24;
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             //DetailsRowLocalRules.Clear();
-            var detailsRowRules = new HashSet<Rule>();
+            var detailsRowRules = new HashSet<IRule>();
 
             // Root
             var rootFocusStyleProps = new FocusStyleProps(theme);

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRowCheck.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRowCheck.razor.cs
@@ -41,9 +41,9 @@ namespace BlazorFluentUI
         [Parameter]
         public bool UseFastIcons { get; set; } = true;
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var detailsRowRules = new HashSet<Rule>();
+            var detailsRowRules = new HashSet<IRule>();
             var focusProps = new FocusStyleProps(theme);
             var focusStyles = FocusStyle.GetFocusStyle(focusProps, ".ms-DetailsRow-check");
 

--- a/src/BlazorFluentUI.BFUDialog/BFUDialogContent.razor.cs
+++ b/src/BlazorFluentUI.BFUDialog/BFUDialogContent.razor.cs
@@ -20,12 +20,12 @@ namespace BlazorFluentUI
         [Parameter] public string TitleId { get; set; }
 
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
             // ToDo Button Selector for Icon when hidden isn't implement so far
             // ToDo Headeer DraggableHeader isn't implement so far
 
-            var GlobalCssRules = new HashSet<Rule>();
+            var GlobalCssRules = new HashSet<IRule>();
             #region ms-Dialog-content
             GlobalCssRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUDropdown/BFUDropdown.razor.cs
+++ b/src/BlazorFluentUI.BFUDropdown/BFUDropdown.razor.cs
@@ -282,9 +282,9 @@ namespace BlazorFluentUI
 
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var dropdownRules = new HashSet<Rule>();
+            var dropdownRules = new HashSet<IRule>();
             #region Root
             dropdownRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUGroupedList/BFUGroupHeader.razor.cs
+++ b/src/BlazorFluentUI.BFUGroupedList/BFUGroupHeader.razor.cs
@@ -73,9 +73,9 @@ namespace BlazorFluentUI
         }
 
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var groupHeaderRules = new HashSet<Rule>();
+            var groupHeaderRules = new HashSet<IRule>();
 
             // Root
             var rootFocusStyleProps = new FocusStyleProps(this.Theme);

--- a/src/BlazorFluentUI.BFUIcon/BFUIcon.razor.cs
+++ b/src/BlazorFluentUI.BFUIcon/BFUIcon.razor.cs
@@ -8,9 +8,9 @@ namespace BlazorFluentUI
         [Parameter] public string IconName { get; set; }
         [Parameter] public IconType IconType { get; set; }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var iconRules = new HashSet<Rule>();
+            var iconRules = new HashSet<IRule>();
             iconRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-Icon" },

--- a/src/BlazorFluentUI.BFUImage/BFUImage.razor.cs
+++ b/src/BlazorFluentUI.BFUImage/BFUImage.razor.cs
@@ -88,9 +88,9 @@ namespace BlazorFluentUI
             return OnLoadingStateChange.InvokeAsync(imageLoadState);
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var imageRules = new HashSet<Rule>();
+            var imageRules = new HashSet<IRule>();
             // ROOT
             imageRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFULabel/BFULabel.razor.cs
+++ b/src/BlazorFluentUI.BFULabel/BFULabel.razor.cs
@@ -26,9 +26,9 @@ namespace BlazorFluentUI
         [Parameter]
         public string HtmlFor { get; set; }  //not being used for anything.
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var labelRules = new HashSet<Rule>();
+            var labelRules = new HashSet<IRule>();
             labelRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Label" }, Properties = new CssString() { Css = $"font-weight:{theme.FontStyle.FontWeight.SemiBold};color:{theme.SemanticTextColors.BodyText};box-sizing:border-box;box-shadow:none;margin:0;display:block;padding: 5px 0px;word-wrap:break-word;overflow-wrap:break-word;" } });
             labelRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Label--disabled" }, Properties = new CssString() { Css = $"color:{theme.SemanticTextColors.DisabledBodyText};" } });
             labelRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Label--required::after" }, Properties = new CssString() { Css = $"content:' *';color:{theme.SemanticTextColors.ErrorText};padding-right:12px;" } });

--- a/src/BlazorFluentUI.BFULayer/BFULayerHost.razor.cs
+++ b/src/BlazorFluentUI.BFULayer/BFULayerHost.razor.cs
@@ -23,9 +23,9 @@ namespace BlazorFluentUI
             portalGeneratorReference.RemoveHostedContent(layerId);
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var layerRules = new HashSet<Rule>();
+            var layerRules = new HashSet<IRule>();
             // ROOT
             layerRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFULink/BFULink.razor.cs
+++ b/src/BlazorFluentUI.BFULink/BFULink.razor.cs
@@ -24,9 +24,9 @@ namespace BlazorFluentUI
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var linkRules = new HashSet<Rule>();
+            var linkRules = new HashSet<IRule>();
             linkRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Link" }, Properties = new CssString() { Css = $"color:{Theme.SemanticTextColors.Link};outline:none;font-size:inherit;font-weight:inherit;" } });
             linkRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Link.isButton" }, Properties = new CssString() { Css = "background:none;background-color:transparent;border:none;cursor:pointer;display:inline;margin:0;overflow:inherit;padding:0;text-align:left;text-overflow:inherit;user-select:text;border-bottom:1px solid transparent;" } });
             linkRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Link:not(.isButton)" }, Properties = new CssString() { Css = "text-decoration:none;" } });

--- a/src/BlazorFluentUI.BFUList/BFUList.razor.cs
+++ b/src/BlazorFluentUI.BFUList/BFUList.razor.cs
@@ -317,9 +317,9 @@ namespace BlazorFluentUI
         //    //Debug.WriteLine("list wants to rerender... but can't");
         //    return false;
         //}
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var listRules = new HashSet<Rule>();
+            var listRules = new HashSet<IRule>();
             //creates a method that pulls in focusstyles the way the react controls do it.
             var focusStyleProps = new FocusStyleProps(this.Theme);
             var mergeStyleResults = FocusStyle.GetFocusStyle(focusStyleProps, ".ms-List-cell-default");

--- a/src/BlazorFluentUI.BFUMessageBar/BFUMessageBar.razor.cs
+++ b/src/BlazorFluentUI.BFUMessageBar/BFUMessageBar.razor.cs
@@ -90,11 +90,11 @@ namespace BlazorFluentUI
             }
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
             // ToDo SmallScreenSelector for innerText isn't implement so far
 
-            var messageBarGlobalRules = new HashSet<Rule>();
+            var messageBarGlobalRules = new HashSet<IRule>();
             #region ms-MessageBar
             messageBarGlobalRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUModal/BFUModal.razor.cs
+++ b/src/BlazorFluentUI.BFUModal/BFUModal.razor.cs
@@ -170,10 +170,10 @@ namespace BlazorFluentUI
             await base.OnAfterRenderAsync(firstRender);
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
 
-            var GlobalCssRules = new HashSet<Rule>();
+            var GlobalCssRules = new HashSet<IRule>();
             #region ms-Modal
             GlobalCssRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUNav/BFUNav.razor.cs
+++ b/src/BlazorFluentUI.BFUNav/BFUNav.razor.cs
@@ -31,9 +31,9 @@ namespace BlazorFluentUI
             StateHasChanged();
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var navRules = new HashSet<Rule>();
+            var navRules = new HashSet<IRule>();
             // ROOT
             navRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUOverflowSet/BFUOverflowSet.razor.cs
+++ b/src/BlazorFluentUI.BFUOverflowSet/BFUOverflowSet.razor.cs
@@ -45,9 +45,9 @@ namespace BlazorFluentUI
             return base.OnParametersSetAsync();
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var overflowSetRules = new HashSet<Rule>();
+            var overflowSetRules = new HashSet<IRule>();
             overflowSetRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-OverflowSet" },

--- a/src/BlazorFluentUI.BFUOverlay/BFUOverlay.razor
+++ b/src/BlazorFluentUI.BFUOverlay/BFUOverlay.razor
@@ -28,9 +28,9 @@
 
     }
 
-    public ICollection<Rule> CreateGlobalCss(ITheme theme)
+    public ICollection<IRule> CreateGlobalCss(ITheme theme)
     {
-        var overlayRules = new HashSet<Rule>();
+        var overlayRules = new HashSet<IRule>();
 
         overlayRules.Add(new Rule()
         {

--- a/src/BlazorFluentUI.BFUPanel/BFUPanel.razor.cs
+++ b/src/BlazorFluentUI.BFUPanel/BFUPanel.razor.cs
@@ -473,9 +473,9 @@ namespace BlazorFluentUI
             }
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var panelRules = new HashSet<Rule>();
+            var panelRules = new HashSet<IRule>();
             
             panelRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUPersona/BFUPersona.razor.cs
+++ b/src/BlazorFluentUI.BFUPersona/BFUPersona.razor.cs
@@ -293,9 +293,9 @@ namespace BlazorFluentUI
             
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var personalRules = new HashSet<Rule>();
+            var personalRules = new HashSet<IRule>();
             // ROOT
             personalRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUPersona/BFUPersonaCoin.razor.cs
+++ b/src/BlazorFluentUI.BFUPersona/BFUPersonaCoin.razor.cs
@@ -186,9 +186,9 @@ namespace BlazorFluentUI
 
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var personaCoinRules = new HashSet<Rule>();
+            var personaCoinRules = new HashSet<IRule>();
 
             personaCoinRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUPersona/BFUPersonaPresence.razor.cs
+++ b/src/BlazorFluentUI.BFUPersona/BFUPersonaPresence.razor.cs
@@ -351,9 +351,9 @@ namespace BlazorFluentUI
             };
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var personaPresenceRules = new HashSet<Rule>();
+            var personaPresenceRules = new HashSet<IRule>();
 
             personaPresenceRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUPivot/BFUPivot.razor.cs
+++ b/src/BlazorFluentUI.BFUPivot/BFUPivot.razor.cs
@@ -153,9 +153,9 @@ namespace BlazorFluentUI
             return;
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var MyRules = new List<Rule>();
+            var MyRules = new List<IRule>();
             #region ms-Pivot-count
             MyRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUProgressIndicator/BFUProgressIndicator.razor.cs
+++ b/src/BlazorFluentUI.BFUProgressIndicator/BFUProgressIndicator.razor.cs
@@ -123,9 +123,9 @@ namespace BlazorFluentUI
             };
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var progressIndicatorGlobalRules = new HashSet<Rule>();
+            var progressIndicatorGlobalRules = new HashSet<IRule>();
             progressIndicatorGlobalRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = "@keyframes IndeterminateProgress" },

--- a/src/BlazorFluentUI.BFURating/BFURating.razor.cs
+++ b/src/BlazorFluentUI.BFURating/BFURating.razor.cs
@@ -131,9 +131,9 @@ namespace BlazorFluentUI
             return fullStar;
         }
 
-        protected ICollection<Rule> CreateGlobalCss()
+        protected ICollection<IRule> CreateGlobalCss()
         {
-            var ratingGlobalRules = new HashSet<Rule>();
+            var ratingGlobalRules = new HashSet<IRule>();
             var FocusStyleRatingFocusZone = FocusStyle.GetFocusStyle(new FocusStyleProps(Theme), ".ms-Rating-focuszone");
             var FocusStyleRatingButton = FocusStyle.GetFocusStyle(new FocusStyleProps(Theme), ".ms-Rating-button");
             foreach (var rule in FocusStyleRatingFocusZone.AddRules)

--- a/src/BlazorFluentUI.BFURichTextEditor/BFURichTextEditor.razor.cs
+++ b/src/BlazorFluentUI.BFURichTextEditor/BFURichTextEditor.razor.cs
@@ -275,9 +275,9 @@ namespace BlazorFluentUI
             isImageDialogOpen = false;
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var richTextEditorGlobalRules = new HashSet<Rule>();
+            var richTextEditorGlobalRules = new HashSet<IRule>();
             richTextEditorGlobalRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".bf-richTextEditor" },

--- a/src/BlazorFluentUI.BFUSpinner/BFUSpinner.razor.cs
+++ b/src/BlazorFluentUI.BFUSpinner/BFUSpinner.razor.cs
@@ -58,9 +58,9 @@ namespace BlazorFluentUI
                     return " ms-Spinner--medium";
             }
         }
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var spinnerRules = new HashSet<Rule>();
+            var spinnerRules = new HashSet<IRule>();
             spinnerRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-Spinner" },

--- a/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
+++ b/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
@@ -295,9 +295,9 @@ namespace BlazorFluentUI
             }
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var MyRules = new List<Rule>();
+            var MyRules = new List<IRule>();
             #region ms-TextField
             MyRules.Add(new Rule()
             {

--- a/src/BlazorFluentUI.BFUToggle/BFUToggle.razor.cs
+++ b/src/BlazorFluentUI.BFUToggle/BFUToggle.razor.cs
@@ -133,9 +133,9 @@ namespace BlazorFluentUI
             return CheckedChanged.InvokeAsync(!IsChecked);
         }
 
-        private ICollection<Rule> CreateGlobalCss()
+        private ICollection<IRule> CreateGlobalCss()
         {
-            var MyRules = new List<Rule>();
+            var MyRules = new List<IRule>();
             MyRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Toggle" }, Properties = new CssString() { Css = $"margin-bottom:8px;" } });
             MyRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Toggle--inlineLabel" }, Properties = new CssString() { Css = "display:flex;align-items:center;" } });
             MyRules.Add(new Rule() { Selector = new CssStringSelector() { SelectorName = ".ms-Toggle--disabled .ms-Toggle-label" }, Properties = new CssString() { Css = $"color:{Theme.SemanticTextColors.DisabledText};" } });

--- a/src/BlazorFluentUI.BFUTooltip/BFUTooltip.razor.cs
+++ b/src/BlazorFluentUI.BFUTooltip/BFUTooltip.razor.cs
@@ -42,9 +42,9 @@ namespace BlazorFluentUI
             TooltipLocalRules.Add(TooltipAfterRule);
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var tooltipGlobalRules = new HashSet<Rule>();
+            var tooltipGlobalRules = new HashSet<IRule>();
             tooltipGlobalRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-Tooltip-content" },

--- a/src/BlazorFluentUI.BFUTooltip/BFUTooltipHost.razor.cs
+++ b/src/BlazorFluentUI.BFUTooltip/BFUTooltipHost.razor.cs
@@ -186,9 +186,9 @@ namespace BlazorFluentUI
             }
         }
 
-        public ICollection<Rule> CreateGlobalCss(ITheme theme)
+        public ICollection<IRule> CreateGlobalCss(ITheme theme)
         {
-            var tooltipHostRules = new HashSet<Rule>();
+            var tooltipHostRules = new HashSet<IRule>();
             tooltipHostRules.Add(new Rule()
             {
                 Selector = new CssStringSelector() { SelectorName = ".ms-TooltipHost" },


### PR DESCRIPTION
The `IHasPreLoadableGlobalStyle` interface should probably use the `IRule` interface instead of the `Rule` implementation in its `CreateGlobalCss` method.