### PR TITLE
Added DisableRenderOnSelectionChanged property to SelectionZone to re…

### DIFF
--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/GroupedListPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/GroupedListPage.razor
@@ -9,6 +9,7 @@
 
 
         <BFUSelectionZone @bind-Selection=@selection
+                          DisableRenderOnSelectionChanged="true"
                           SelectionMode=@SelectionMode.Multiple>
             <BFUFocusZone Direction="FocusZoneDirection.Vertical"
                           Style="height:100%;overflow-y:hidden;">

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsList.razor
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsList.razor
@@ -44,6 +44,7 @@
                 {
                     <BFUSelectionZone Selection=@Selection
                                    @ref="selectionZone"
+                                      DisableRenderOnSelectionChanged="true"
                                    SelectionChanged=@SelectionChanged
                                    SelectionPreservedOnEmptyClick=@SelectionPreservedOnEmptyClick
                                    SelectionMode=@SelectionMode

--- a/src/BlazorFluentUI.BFUSelectionZone/BFUSelectionZone.razor.cs
+++ b/src/BlazorFluentUI.BFUSelectionZone/BFUSelectionZone.razor.cs
@@ -18,6 +18,9 @@ namespace BlazorFluentUI
         public bool DisableAutoSelectOnInputElements { get; set; }
 
         [Parameter]
+        public bool DisableRenderOnSelectionChanged { get; set; } = false;
+
+        [Parameter]
         public bool EnterModalOnTouch { get; set; }
 
         [Parameter]
@@ -52,11 +55,13 @@ namespace BlazorFluentUI
 
         protected override bool ShouldRender()
         {
-            if (doNotRenderOnce)
+            if (doNotRenderOnce && DisableRenderOnSelectionChanged)
             {
                 doNotRenderOnce = false;
                 return false;
             }
+            else
+                doNotRenderOnce = false;
 
             return true;
             //return base.ShouldRender();


### PR DESCRIPTION
…tain original behavior for basic List, but when set to true, you can only get changes by subscribing to the SelectedItemsObservable from the cascading parameter SelectionZone.  This dramatically speeds up rendering since only the changed items will rerender instead of the entire list.

(Forgot to check the original List where selection didn't work anymore.  Now it does)