### PR TITLE
Fix issue with details list scrolling up when changing selections in compact mode

### DIFF
--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
@@ -230,8 +230,7 @@ namespace BlazorFluentUI
                 {
                     Css = rootSelectedMergeStyleResults.MergeRules + 
                           $"color:{theme.Palette.NeutralDark};" +
-                          $"background:{theme.Palette.NeutralLight};" +
-                          $"border-bottom:1px solid {theme.Palette.White};"
+                          $"background:{theme.Palette.NeutralLight};"
                 }
             });
             detailsRowRules.Add(new Rule()


### PR DESCRIPTION
When using the details list in compact mode, the list will scroll up when selecting the next item in the list. This was caused by a border being added to the selected item.
![image](https://user-images.githubusercontent.com/5934505/87000054-fdf9fd80-c168-11ea-8faf-1d7ac30e140b.png)

Before:
![before](https://user-images.githubusercontent.com/5934505/86999657-f423ca80-c167-11ea-98fd-5b99d879db89.gif)

After:
![after](https://user-images.githubusercontent.com/5934505/86999651-f25a0700-c167-11ea-9eff-25cbb98f5148.gif)