### PR TITLE
Hotfix/#214 bfutextfield change onchange and oninput return type to changeeventargs

### DIFF
--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPage.razor
@@ -18,7 +18,7 @@
         </BFUStack>
         <BFUTextField Label="Filter Description"
                    @bind-Value=@dataContainer.Filter
-                   @bind-Value:event="OnInput"/>
+                   @oninput="UpdateFilter"/>
 
         <BFUDetailsList ItemsSource="ReadonlyList"
                         IsVirtualizing="isVirtualizing"
@@ -192,5 +192,10 @@
 
     }
 
+
+    public void UpdateFilter(ChangeEventArgs changeEventArgs)
+    {
+        dataContainer.Filter = changeEventArgs.Value.ToString();
+    }
 
 }

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/TextFieldPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/TextFieldPage.razor
@@ -114,12 +114,12 @@
 <h2>Binding Mode</h2>
 
 <div class="textFieldDiv" style="display:flex; flex-direction: row">
-    <BFUTextField Label="TextField OnInput 1" @bind-Value=@onInputContent @bind-Value:event="OnInput" />
-    <BFUTextField Label="TextField OnInput 2" @bind-Value=@onInputContent @bind-Value:event="OnInput" />
+    <BFUTextField Label="TextField OnInput 1" @bind-Value=@onInputContent @oninput="UpdateOnInputContent"/>
+    <BFUTextField Label="TextField OnInput 2" @bind-Value=@onInputContent @oninput="UpdateOnInputContent" />
 </div>
 <div class="textFieldDiv" style="display:flex; flex-direction: row">
-    <BFUTextField Label="TextField OnChange 1" @bind-Value=@onChangeContent @bind-Value:event="OnChange" />
-    <BFUTextField Label="TextField OnChange 2" @bind-Value=@onChangeContent @bind-Value:event="OnChange" />
+    <BFUTextField Label="TextField OnChange 1" @bind-Value=@onChangeContent @onchange="UpdateOnChangeContent" />
+    <BFUTextField Label="TextField OnChange 2" @bind-Value=@onChangeContent @onchange="UpdateOnChangeContent" />
 </div>
 
 <h2>TextField error message variations</h2>
@@ -161,5 +161,15 @@
     public string GetErrorMessage(string value)
     {
         return value.Length < 3 ? "" : $"Input value length must be less than 3. Actual length is {value.Length}.";
+    }
+
+    private void UpdateOnInputContent(ChangeEventArgs e)
+    {
+        onInputContent = e.Value.ToString();
+    }
+
+    private void UpdateOnChangeContent(ChangeEventArgs e)
+    {
+        onChangeContent = e.Value.ToString();
     }
 }

--- a/src/BlazorFluentUI.BFUDatePicker/BFUDatePicker.razor.cs
+++ b/src/BlazorFluentUI.BFUDatePicker/BFUDatePicker.razor.cs
@@ -204,18 +204,20 @@ namespace BlazorFluentUI
             }
         }
 
-        protected void OnTextFieldChange(string text)
+        protected void OnTextFieldChange(ChangeEventArgs args)
         {
+            String? textFieldValue = args?.Value.ToString();
+
             if (AllowTextInput)
             {
                 if (IsDatePickerShown)
                     DismissDatePickerPopup();
             }
 
-            if (FormattedDate != text)
+            if (FormattedDate != textFieldValue)
             {
                 ErrorMessage = IsRequired && (Value == DateTime.MinValue) ? IsRequiredErrorMessage : null;
-                FormattedDate = text;
+                FormattedDate = textFieldValue ?? "";
             }
             // skip TextField OnChange callback ... not implemented through DatePicker
         }

--- a/src/BlazorFluentUI.BFURichTextEditor/BFURichTextEditor.razor
+++ b/src/BlazorFluentUI.BFURichTextEditor/BFURichTextEditor.razor
@@ -24,11 +24,11 @@
         OnDismiss=@(args => isImageDialogOpen=false)>
     <ChildContent>
         <BFUStack>
-            <BFUTextField ClassName="firstFocus" Label="Image Link" @bind-Value=@imageUrl @bind-Value:event="OnInput" />
-            <BFUTextField Label="Image Alternate Text" @bind-Value=@imageAlt @bind-Value:event="OnInput" />
+            <BFUTextField ClassName="firstFocus" Label="Image Link" @bind-Value=@imageUrl @oninput="UpdateImageUrl" />
+            <BFUTextField Label="Image Alternate Text" @bind-Value=@imageAlt @oninput="UpdateImageAlt" />
             <BFUStack Horizontal="true">
-                <BFUTextField Label="Horizontal Size" Placeholder="auto" Description="auto if empty" @bind-Value=@imageWidth @bind-Value:event="OnInput" />
-                <BFUTextField Label="Vertical Size" Placeholder="auto" Description="auto if empty" @bind-Value=@imageHeight @bind-Value:event="OnInput" />
+                <BFUTextField Label="Horizontal Size" Placeholder="auto" Description="auto if empty" @bind-Value=@imageWidth @oninput="UpdateImageWidth" />
+                <BFUTextField Label="Vertical Size" Placeholder="auto" Description="auto if empty" @bind-Value=@imageHeight @oninput="UpdateImageHeight" />
             </BFUStack>
         </BFUStack>
     </ChildContent>

--- a/src/BlazorFluentUI.BFURichTextEditor/BFURichTextEditor.razor.cs
+++ b/src/BlazorFluentUI.BFURichTextEditor/BFURichTextEditor.razor.cs
@@ -389,6 +389,26 @@ namespace BlazorFluentUI
         }
             });
             return richTextEditorGlobalRules;
+        }        
+
+        public void UpdateImageUrl(ChangeEventArgs args)
+        {
+            imageUrl = args.Value.ToString();
+        }
+
+        public void UpdateImageHeight(ChangeEventArgs args)
+        {
+            imageHeight = args.Value.ToString();
+        }
+
+        public void UpdateImageWidth(ChangeEventArgs args)
+        {
+            imageWidth = args.Value.ToString();
+        }
+
+        public void UpdateImageAlt(ChangeEventArgs args)
+        {
+            imageAlt = args.Value.ToString();
         }
     }
 }

--- a/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
+++ b/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
@@ -5,7 +5,6 @@ using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace BlazorFluentUI
@@ -68,9 +67,9 @@ namespace BlazorFluentUI
         //[Parameter]
         //protected Func<UIChangeEventArgs, Task> OnInput { get; set; }
         [Parameter]
-        public EventCallback<ChangeEventArgs> OnChange { get; set; }
+        public EventCallback<string> OnChange { get; set; }
         [Parameter]
-        public EventCallback<ChangeEventArgs> OnInput { get; set; }
+        public EventCallback<string> OnInput { get; set; }
         [Parameter]
         public EventCallback<string> ValueChanged { get; set; }
 
@@ -176,7 +175,11 @@ namespace BlazorFluentUI
                 await DeferredValidation((string)args.Value).ConfigureAwait(false);
             }
 
-            await OnInput.InvokeAsync((ChangeEventArgs)args.Value);
+<<<<<<< HEAD
+            await OnInput.InvokeAsync(args);
+=======
+            await OnInput.InvokeAsync((string)args.Value);
+>>>>>>> parent of 775367b... Change onchange and oninput events to return ChangeEventArgs instead of String.
             //await InputChanged.InvokeAsync((string)args.Value);
             //if (this.OnInput != null)
             //{
@@ -186,7 +189,11 @@ namespace BlazorFluentUI
 
         protected async Task ChangeHandler(ChangeEventArgs args)
         {
-            await OnChange.InvokeAsync((ChangeEventArgs)args.Value);
+<<<<<<< HEAD
+            await OnChange.InvokeAsync(args);
+=======
+            await OnChange.InvokeAsync((string)args.Value);
+>>>>>>> parent of 775367b... Change onchange and oninput events to return ChangeEventArgs instead of String.
             await ValueChanged.InvokeAsync((string)args.Value);
         }
 

--- a/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
+++ b/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
@@ -67,9 +67,9 @@ namespace BlazorFluentUI
         //[Parameter]
         //protected Func<UIChangeEventArgs, Task> OnInput { get; set; }
         [Parameter]
-        public EventCallback<string> OnChange { get; set; }
+        public EventCallback<ChangeEventArgs> OnChange { get; set; }
         [Parameter]
-        public EventCallback<string> OnInput { get; set; }
+        public EventCallback<ChangeEventArgs> OnInput { get; set; }
         [Parameter]
         public EventCallback<string> ValueChanged { get; set; }
 
@@ -175,25 +175,14 @@ namespace BlazorFluentUI
                 await DeferredValidation((string)args.Value).ConfigureAwait(false);
             }
 
-<<<<<<< HEAD
             await OnInput.InvokeAsync(args);
-=======
-            await OnInput.InvokeAsync((string)args.Value);
->>>>>>> parent of 775367b... Change onchange and oninput events to return ChangeEventArgs instead of String.
-            //await InputChanged.InvokeAsync((string)args.Value);
-            //if (this.OnInput != null)
-            //{
-            //    await this.OnInput.Invoke(args);
-            //}
         }
 
         protected async Task ChangeHandler(ChangeEventArgs args)
         {
-<<<<<<< HEAD
+
             await OnChange.InvokeAsync(args);
-=======
-            await OnChange.InvokeAsync((string)args.Value);
->>>>>>> parent of 775367b... Change onchange and oninput events to return ChangeEventArgs instead of String.
+
             await ValueChanged.InvokeAsync((string)args.Value);
         }
 

--- a/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
+++ b/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
@@ -68,9 +68,9 @@ namespace BlazorFluentUI
         //[Parameter]
         //protected Func<UIChangeEventArgs, Task> OnInput { get; set; }
         [Parameter]
-        public EventCallback<string> OnChange { get; set; }
+        public EventCallback<ChangeEventArgs> OnChange { get; set; }
         [Parameter]
-        public EventCallback<string> OnInput { get; set; }
+        public EventCallback<ChangeEventArgs> OnInput { get; set; }
         [Parameter]
         public EventCallback<string> ValueChanged { get; set; }
 
@@ -176,7 +176,7 @@ namespace BlazorFluentUI
                 await DeferredValidation((string)args.Value).ConfigureAwait(false);
             }
 
-            await OnInput.InvokeAsync((string)args.Value);
+            await OnInput.InvokeAsync((ChangeEventArgs)args.Value);
             //await InputChanged.InvokeAsync((string)args.Value);
             //if (this.OnInput != null)
             //{
@@ -186,7 +186,7 @@ namespace BlazorFluentUI
 
         protected async Task ChangeHandler(ChangeEventArgs args)
         {
-            await OnChange.InvokeAsync((string)args.Value);
+            await OnChange.InvokeAsync((ChangeEventArgs)args.Value);
             await ValueChanged.InvokeAsync((string)args.Value);
         }
 


### PR DESCRIPTION
I've changed onchange and oninput type from string to changeeventargs.
This is how blaozr currently handling the onchange and oninput event.
https://docs.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?view=aspnetcore-3.1