### PR TITLE
remove an obsolete bracket in detail row

### DIFF
--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor
@@ -47,7 +47,7 @@
 
             @if (columnMeasureInfo != null)
             {
-                <span role="presentation" 
+                <span role="presentation"
                       class="ms-DetailsRow-cellMeasurer ms-DetailsRow-cell"
                       @ref="cellMeasurer">
                     <BFUDetailsRowFields Item=@Item
@@ -56,7 +56,6 @@
                 </span>
             }
         }
-    }
 
     <span role="checkbox" class="@($"ms-DetailsRow-checkCover {_localCheckCoverRule.Selector.SelectorName}")" aria-checked=@isSelected data-selection-toggle="true" />
 

--- a/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
+++ b/src/BlazorFluentUI.BFUTextField/BFUTextField.razor.cs
@@ -253,12 +253,6 @@ namespace BlazorFluentUI
             if (CascadedEditContext != null && ValueExpression != null)
             {
                 CascadedEditContext.OnValidationStateChanged += CascadedEditContext_OnValidationStateChanged;
-
-                //if (ValueExpression == null)
-                //{
-                //    throw new InvalidOperationException($"{GetType()} requires a value for the 'ValueExpression' " +
-                //        $"parameter. Normally this is provided automatically when using 'bind-Value'.");
-                //}
                 FieldIdentifier = FieldIdentifier.Create<string>(ValueExpression);
             }
 


### PR DESCRIPTION
This removes the bracket visible in the detaillist mentioned in #229.