### PR TITLE
restore detail list click behaviour

### DIFF
--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPageBasic.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPageBasic.razor
@@ -6,6 +6,8 @@
                     Columns="Columns"
                     GetKey=@(item=>item.Key)
                     LayoutMode="DetailsListLayoutMode.Justified"
+                    TItem="DataItem"
+                    OnItemInvoked="OnClick"
                     Selection="selection"
                     SelectionMode="SelectionMode.Multiple">
     </BFUDetailsList>
@@ -42,5 +44,10 @@
         InputList = new List<DataItem>(column.IsSorted ? InputList.OrderBy(x => x.DisplayName) : InputList.OrderByDescending(x => x.DisplayName));
         column.IsSorted = !column.IsSorted;
         StateHasChanged();
+    }
+
+    private void OnClick(DataItem item)
+    {
+        Console.WriteLine("Clicked!");
     }
 }

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsColumn.razor
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsColumn.razor
@@ -2,14 +2,13 @@
 @inherits BFUComponentBase
 @typeparam TItem
 
-@*<BFUGlobalCS Component=@this CreateGlobalCss=@(()=>CreateGlobalCss(Theme)) />*@
 <div role="columnheader"
      aria-sort=@(Column.IsSorted ? (Column.IsSortedDescending ? "descending" : "ascending"): "none")
      aria-colindex=@ColumnIndex
      class=@($"ms-DetailsColumn{(Column.ColumnActionsMode != ColumnActionsMode.Disabled ? " is-actionable" : "")}{(string.IsNullOrEmpty(Column.Name) ? " is-empty" : "")}{(Column.IsPadded ? " is-padded" : "")}{(Column.IsIconOnly ? " is-iconOnly" : "")}")
      data-is-draggable=@IsDraggable
      draggable=@IsDraggable
-     style=@($"width:{(Column.CalculatedWidth + BFUDetailsRow<TItem>.CellLeftPadding + BFUDetailsRow<TItem>.CellRightPadding + (Column.IsPadded ? BFUDetailsRow<TItem>.CellExtraRightPadding : 0))}px;")>
+     style=@($"width:{(Column.CalculatedWidth + BFUDetailsRow<TItem>.CELL_LEFT_PADDING + BFUDetailsRow<TItem>.CELL_RIGHT_PADDING + (Column.IsPadded ? BFUDetailsRow<TItem>.CELL_EXTRA_RIGHT_PADDING : 0))}px;")>
     @if (IsDraggable)
     {
         @if (UseFastIcons)

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsList.razor
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsList.razor
@@ -11,7 +11,7 @@
          aria-label=@AriaLabel
          aria-readonly=true
          style="display:flex;flex-direction:column;">
-        <div 
+        <div
              role="presentation"
              class="ms-DetailsList-headerWrapper">
             @if (IsHeaderVisible)
@@ -34,13 +34,11 @@
                                       OnColumnAutoResized=@OnColumnAutoResized
                                       OnColumnResized=@OnColumnResizedInternal
                                       CheckboxVisibility=@CheckboxVisibility
-                                      SelectAllVisibility=@selectAllVisibility
-                                      
-                                      />
+                                      SelectAllVisibility=@selectAllVisibility />
                 }
             }
         </div>
-        <div 
+        <div
              role="presentation"
              class="ms-DetailsList-contentWrapper"
              style="overflow-y:hidden;height:100%;">
@@ -56,8 +54,7 @@
                                    SelectionPreservedOnEmptyClick=@SelectionPreservedOnEmptyClick
                                    SelectionMode=@SelectionMode
                                    EnterModalOnTouch=@EnterModalSelectionOnTouch
-                                   OnItemInvoked=@((item,index) => this.OnItemInvoked.InvokeAsync(item))
-                                   >
+                                   OnItemInvoked=@((item,index) => this.OnItemInvoked.InvokeAsync(item)) >
                         @if (SubGroupSelector == null)
                         {
                             <BFUList ItemsSource=@ItemsSource
@@ -100,7 +97,7 @@
                                                     Selection=@Selection
                                                    Columns=@_adjustedColumns
                                                    SelectionMode=@(CheckboxVisibility != CheckboxVisibility.Hidden ? SelectionMode : SelectionMode.None)
-                                                
+
                                                    CheckboxVisibility=@CheckboxVisibility
                                                    Compact=@Compact />
                                 </ItemTemplate>
@@ -113,8 +110,7 @@
                 {
                     @if (SubGroupSelector == null)
                     {
-                        <BFUList ItemsSource=@ItemsSource
-                              >
+                        <BFUList ItemsSource=@ItemsSource >
                             <ItemTemplate>
                                 @if (RowTemplate != null)
                                 {

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsList.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsList.razor.cs
@@ -387,9 +387,9 @@ namespace BlazorFluentUI
         private double GetPaddedWidth(BFUDetailsRowColumn<TItem> column, bool isFirst)
         {
             return column.CalculatedWidth +
-                    BFUDetailsRow<TItem>.CellLeftPadding +
-                    BFUDetailsRow<TItem>.CellRightPadding +
-                    (column.IsPadded ? BFUDetailsRow<TItem>.CellExtraRightPadding : 0);
+                    BFUDetailsRow<TItem>.CELL_LEFT_PADDING +
+                    BFUDetailsRow<TItem>.CELL_RIGHT_PADDING +
+                    (column.IsPadded ? BFUDetailsRow<TItem>.CELL_EXTRA_RIGHT_PADDING : 0);
         }
 
         private void OnColumnResizedInternal(ColumnResizedArgs<TItem> columnResizedArgs)

--- a/src/BlazorFluentUI.BFUDetailsList/BFUDetailsListAuto.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsList/BFUDetailsListAuto.razor.cs
@@ -691,9 +691,9 @@ namespace BlazorFluentUI
         private double GetPaddedWidth(BFUDetailsRowColumn<TItem> column, bool isFirst)
         {
             return column.CalculatedWidth +
-                    BFUDetailsRow<TItem>.CellLeftPadding +
-                    BFUDetailsRow<TItem>.CellRightPadding +
-                    (column.IsPadded ? BFUDetailsRow<TItem>.CellExtraRightPadding : 0);
+                    BFUDetailsRow<TItem>.CELL_LEFT_PADDING +
+                    BFUDetailsRow<TItem>.CELL_RIGHT_PADDING +
+                    (column.IsPadded ? BFUDetailsRow<TItem>.CELL_EXTRA_RIGHT_PADDING : 0);
         }
 
         private void OnColumnResizedInternal(ColumnResizedArgs<TItem> columnResizedArgs)

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor
@@ -18,6 +18,7 @@
                   ClassName=@($"fadeIn400 {(Compact ? "is-compact " : "")}{(isSelected ? "is-selected " : "")}{(IsRowHeader ? "is-row-header " : "")}{(IsCheckVisible ? "is-check-visible " : "")}ms-DetailsRow")
                   AllowFocusRoot="true"
                   IsFocusable="true"
+                  OnClick=@OnClick
                   >
 
         @if (showCheckbox)
@@ -47,7 +48,7 @@
 
             @if (columnMeasureInfo != null)
             {
-                <span role="presentation" 
+                <span role="presentation"
                       class="ms-DetailsRow-cellMeasurer ms-DetailsRow-cell"
                       @ref="cellMeasurer">
                     <BFUDetailsRowFields Item=@Item

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor
@@ -1,25 +1,23 @@
 ﻿@namespace BlazorFluentUI
 @inherits BFUComponentBase
 @typeparam TItem
-@using Microsoft.AspNetCore.Components.Web
 
 <BFULocalCS @bind-Rules=@DetailsRowLocalRules />
 
-@*<div @onclick="args => SelectionZone.SelectItem(Item,true)" data-is-focusable="true">*@
 <div class="root"
      data-selection-index=@ItemIndex
      data-selection-touch-invoke="true"
      data-item-index=@ItemIndex
      aria-rowindex=@(ItemIndex + 1)
      data-automationid="DetailsRow">
+
     <BFUFocusZone Direction=@FocusZoneDirection.Horizontal
                   AriaLabel=@AriaLabel
                   AriaDescribedBy=@AriaDescribedBy
                   ClassName=@($"fadeIn400 {(Compact ? "is-compact " : "")}{(isSelected ? "is-selected " : "")}{(IsRowHeader ? "is-row-header " : "")}{(IsCheckVisible ? "is-check-visible " : "")}ms-DetailsRow")
                   AllowFocusRoot="true"
                   IsFocusable="true"
-                  OnClick=@OnClick
-                  >
+                  OnClick=@OnClick >
 
         @if (showCheckbox)
         {
@@ -29,6 +27,7 @@
                  class="ms-DetailsRow-checkCell"
                  @onclick="args => { }"
                  @onclick:stopPropagation="true">
+
                 <BFUDetailsRowCheck IsVisible=@(this.CheckboxVisibility == CheckboxVisibility.Always)
                                     Compact=@Compact
                                     Checked=@isSelected
@@ -51,6 +50,7 @@
                 <span role="presentation"
                       class="ms-DetailsRow-cellMeasurer ms-DetailsRow-cell"
                       @ref="cellMeasurer">
+
                     <BFUDetailsRowFields Item=@Item
                                          Columns=@Columns
                                          ColumnStartIndex=@((showCheckbox ? 1 : 0) + Columns.Count()) />
@@ -59,7 +59,7 @@
         }
     }
 
-    <span role="checkbox" class="@($"ms-DetailsRow-checkCover {_localCheckCoverRule.Selector.SelectorName}")" aria-checked=@isSelected data-selection-toggle="true" />
+    <span role="checkbox" class="@($"ms-DetailsRow-checkCover {localCheckCoverRule.Selector.SelectorName}")" aria-checked=@isSelected data-selection-toggle="true" />
 
     </BFUFocusZone>
 </div>

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
@@ -4,7 +4,6 @@ using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
 
 namespace BlazorFluentUI
@@ -12,7 +11,7 @@ namespace BlazorFluentUI
     public partial class BFUDetailsRow<TItem> : BFUComponentBase, IAsyncDisposable
     {
         [CascadingParameter]
-        public BFUSelectionZone<TItem> SelectionZone { get; set; } = null!
+        public BFUSelectionZone<TItem> SelectionZone { get; set; } = null!;
 
         [Parameter]
         public CheckboxVisibility CheckboxVisibility { get; set; } = CheckboxVisibility.OnHover;
@@ -69,17 +68,17 @@ namespace BlazorFluentUI
         public bool UseFastIcons { get; set; } = true;
 
         [Inject]
-        private IJSRuntime JSRuntime { get; set; } = null!
+        private IJSRuntime JSRuntime { get; set; } = null!;
 
         private bool canSelect;
         private bool showCheckbox;
         private ColumnMeasureInfo<TItem> columnMeasureInfo = null;
-        private readonly ElementReference cellMeasurer;
+        private ElementReference cellMeasurer;
         private bool isSelected;
         private bool isSelectionModal;
-        private Rule _localCheckCoverRule;
-        private Selection<TItem> _selection;
-        private IDisposable _selectionSubscription;
+        private Rule localCheckCoverRule;
+        private Selection<TItem> selection;
+        private IDisposable selectionSubscription;
 
         private ICollection<IRule> DetailsRowLocalRules { get; set; } = new List<IRule>();
 
@@ -97,12 +96,12 @@ namespace BlazorFluentUI
 
         private void CreateLocalCss()
         {
-            _localCheckCoverRule = new Rule
+            localCheckCoverRule = new Rule
             {
                 Selector = new ClassSelector() { SelectorName = "ms-DetailsRow-checkCover" },
                 Properties = new CssString() { Css = $"position:absolute;top:-1px;left:0;bottom:0;right:0;display:{(AnySelected ? "block" : "none")};" }
             };
-            DetailsRowLocalRules.Add(_localCheckCoverRule);
+            DetailsRowLocalRules.Add(localCheckCoverRule);
         }
 
         protected override Task OnParametersSetAsync()
@@ -110,19 +109,19 @@ namespace BlazorFluentUI
             showCheckbox = SelectionMode != SelectionMode.None && CheckboxVisibility != CheckboxVisibility.Hidden;
             canSelect = SelectionMode != SelectionMode.None;
 
-            if (Selection != _selection)
+            if (Selection != selection)
             {
-                if (_selectionSubscription != null)
+                if (selectionSubscription != null)
                 {
-                    _selectionSubscription.Dispose();
+                    selectionSubscription.Dispose();
                 }
 
-                _selection = Selection;
+                selection = Selection;
 
                 if (Selection != null)
                 {
 
-                    _selectionSubscription = Selection.SelectionChanged.Subscribe(_ =>
+                    selectionSubscription = Selection.SelectionChanged.Subscribe(_ =>
                     {
                         bool changed = false;
                         bool newIsSelected;
@@ -208,7 +207,7 @@ namespace BlazorFluentUI
         public async ValueTask DisposeAsync()
         {
             await OnRowWillUnmount.InvokeAsync(this);
-            _selectionSubscription?.Dispose();
+            selectionSubscription?.Dispose();
         }
     }
 }

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
@@ -164,7 +164,6 @@ namespace BlazorFluentUI
                 }
             }
 
-            //CreateCss();
             return base.OnParametersSetAsync();
         }
 
@@ -189,7 +188,7 @@ namespace BlazorFluentUI
                 Rectangle? size = await JSRuntime.InvokeAsync<Rectangle>("BlazorFluentUiBaseComponent.measureElementRect", cellMeasurer);
                 method(size.width);
                 columnMeasureInfo = null;
-                InvokeAsync(StateHasChanged);
+                await InvokeAsync(StateHasChanged);
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
+++ b/src/BlazorFluentUI.BFUDetailsRow/BFUDetailsRow.razor.cs
@@ -168,13 +168,13 @@ namespace BlazorFluentUI
             return base.OnParametersSetAsync();
         }
 
-        public static int RowVerticalPadding = 11;
-        public static int CompactRowVerticalPadding = 6;
-        public static int RowHeight = 42;
-        public static int CompactRowHeight = 32;
-        public static int CellLeftPadding = 12;
-        public static int CellRightPadding = 8;
-        public static int CellExtraRightPadding = 24;
+        public const int ROW_VERTICAL_PADDING= 11;
+        public const int COMPACT_ROW_VERTICAL_PADDING = 6;
+        public const int ROW_HEIGHT = 42;
+        public const int COMPACT_ROW_HEIGHT = 32;
+        public const int CELL_LEFT_PADDING = 12;
+        public const int CELL_RIGHT_PADDING = 8;
+        public const int CELL_EXTRA_RIGHT_PADDING = 24;
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {


### PR DESCRIPTION
This PR should restore the click behaviour of version 3.x: a click on the item itself calls the "InvokeItem" event. A click on the circle at the beginning of the row selects the item. This should be consistent with how react fluentUI handles it.