### PR TITLE
Make isCollapsed readble as public in BFUNavLinkGroup instances

### DIFF
--- a/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor
+++ b/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor
@@ -2,7 +2,7 @@
 @inherits BFUComponentBase
 
 <div key={groupIndex}
-     class=@($"ms-Nav-group {(this.isExpanded ? "is-expanded":"")} {ClassName}")
+     class=@($"ms-Nav-group {(this.isCollapsed ? "is-expanded":"")} {ClassName}")
      style=@Style
      @ref="RootElementReference">
     @if (Name != null)

--- a/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor
+++ b/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor
@@ -2,7 +2,7 @@
 @inherits BFUComponentBase
 
 <div key={groupIndex}
-     class=@($"ms-Nav-group {(this.isCollapsed ? "is-expanded":"")} {ClassName}")
+     class=@($"ms-Nav-group {(!this.isCollapsed ? "is-expanded":"")} {ClassName}")
      style=@Style
      @ref="RootElementReference">
     @if (Name != null)

--- a/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor.cs
+++ b/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor.cs
@@ -35,7 +35,7 @@ namespace BlazorFluentUI
         protected override Task OnParametersSetAsync()
         {
             if (!hasRenderedOnce)
-                isCollapsed = !CollapseByDefault;
+                isCollapsed = CollapseByDefault;
             return base.OnParametersSetAsync();
         }
 

--- a/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor.cs
+++ b/src/BlazorFluentUI.BFUNav/BFUNavLinkGroup.razor.cs
@@ -15,18 +15,19 @@ namespace BlazorFluentUI
 
         [Parameter] public EventCallback<BFUNavLinkGroup> OnClick { get; set; }
 
-        protected bool isExpanded = true;
+        public bool isCollapsed { get; protected set; }
         private bool hasRenderedOnce;
 
         protected async Task ClickHandler(MouseEventArgs args)
         {
-            isExpanded = !isExpanded;
+            isCollapsed = !isCollapsed;
             await OnClick.InvokeAsync(this);
             //return Task.CompletedTask;
         }
 
         protected override Task OnInitializedAsync()
         {
+            isCollapsed = false;
             //System.Diagnostics.Debug.WriteLine("Initializing NavLinkGroupBase");
             return base.OnInitializedAsync();
         }
@@ -34,7 +35,7 @@ namespace BlazorFluentUI
         protected override Task OnParametersSetAsync()
         {
             if (!hasRenderedOnce)
-                isExpanded = !CollapseByDefault;
+                isCollapsed = !CollapseByDefault;
             return base.OnParametersSetAsync();
         }
 


### PR DESCRIPTION
- Renamed isExpanded to isCollapsed to match the parameter `CollapseByDefault`.
- Changed isCollapsed to have `get` public, while remaining protected on `set`.