### PR TITLE
Fixed persona coin initials colour issue

### DIFF
--- a/src/BlazorFluentUI.CoreComponents/Persona/Persona.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/Persona/Persona.razor.cs
@@ -19,7 +19,7 @@ namespace BlazorFluentUI
         [Parameter] public bool ImageShouldFadeIn { get; set; }
         [Parameter] public bool ImageShouldStartVisible { get; set; }
         [Parameter] public string? ImageUrl { get; set; }
-        [Parameter] public PersonaInitialsColor InitialsColor { get; set; }
+        [Parameter] public PersonaInitialsColor? InitialsColor { get; set; }
         [Parameter] public bool IsOutOfOffice { get; set; }
         [Parameter] public string? OptionalText { get; set; }
         [Parameter] public PersonaPresenceStatus Presence { get; set; }

--- a/src/BlazorFluentUI.CoreComponents/Persona/PersonaCoin.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/Persona/PersonaCoin.razor.cs
@@ -20,7 +20,7 @@ namespace BlazorFluentUI
         [Parameter] public bool IsOutOfOffice { get; set; }
         [Parameter] public PersonaPresenceStatus Presence { get; set; }
         [Parameter] public string? PresenceTitle { get; set; }  //tooltip on hover
-        [Parameter] public PersonaInitialsColor InitialsColor { get; set; }
+        [Parameter] public PersonaInitialsColor? InitialsColor { get; set; }
         [Parameter] public bool ShowInitialsUntilImageLoads { get; set; }
         [Parameter] public bool ShowUnknownPersonaCoin { get; set; }
         [Parameter] public string? Size { get; set; }
@@ -149,7 +149,7 @@ namespace BlazorFluentUI
                 >= 100 => Theme?.FontStyle.FontSize.SuperLarge,
             };
 
-            string color = InitialsColor.ToString() != "" ? PersonaColorUtils.GetPersonaColorHexCode(InitialsColor) : PersonaColorUtils.GetPersonaColorHexCode(PersonaColorUtils.GetInitialsColorFromName(Text));
+            string color = InitialsColor.HasValue ? PersonaColorUtils.GetPersonaColorHexCode(InitialsColor.Value) : PersonaColorUtils.GetPersonaColorHexCode(PersonaColorUtils.GetInitialsColorFromName(Text));
 
             InitialsRule.Properties = new CssString
             {


### PR DESCRIPTION
Persona coin was updating the colour based on the first letter from first and last word.
the initials colour has been changed from string to enum.
In code below, because the colour is enum the if statement below will always be true.
string color = InitialsColor.ToString() != "" ? PersonaColorUtils.GetPersonaColorHexCode(InitialsColor) : PersonaColorUtils.GetPersonaColorHexCode(PersonaColorUtils.GetInitialsColorFromName(Text));