### PR TITLE
Added IsBeakVisible and GapSpace to tooltip & tooltiphost

### DIFF
--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/TooltipPage.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/TooltipPage.md
@@ -47,12 +47,12 @@
                     </ChildContent>
                 </TooltipHost>
                 
-                <TooltipHost IsBreakVisible="false">
+                <TooltipHost IsBeakVisible="false">
                     <TooltipContent>
                         Hey, look here!
                     </TooltipContent>
                     <ChildContent>
-                        <DefaultButton>Without break</DefaultButton>
+                        <DefaultButton>Without beak</DefaultButton>
                     </ChildContent>
                 </TooltipHost>
             </Demo>

--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/TooltipPage.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/TooltipPage.md
@@ -29,12 +29,30 @@
     <div>
         <div class="subSection">
             <Demo Header="Tooltip" Key="0" MetadataPath="TooltipPage">
-               <TooltipHost>
+                <TooltipHost>
                     <TooltipContent>
                         Hey, look here!
                     </TooltipContent>
                     <ChildContent>
                         <DefaultButton>Hover to see a tooltip</DefaultButton>
+                    </ChildContent>
+                </TooltipHost>
+                
+                <TooltipHost GapSpace="10">
+                    <TooltipContent>
+                        Hey, look here!
+                    </TooltipContent>
+                    <ChildContent>
+                        <DefaultButton>With gap</DefaultButton>
+                    </ChildContent>
+                </TooltipHost>
+                
+                <TooltipHost IsBreakVisible="false">
+                    <TooltipContent>
+                        Hey, look here!
+                    </TooltipContent>
+                    <ChildContent>
+                        <DefaultButton>Without break</DefaultButton>
                     </ChildContent>
                 </TooltipHost>
             </Demo>

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/TooltipPage.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/TooltipPage.md
@@ -47,12 +47,12 @@
                     </ChildContent>
                 </TooltipHost>
                 
-                <TooltipHost IsBreakVisible="false">
+                <TooltipHost IsBeakVisible="false">
                     <TooltipContent>
                         Hey, look here!
                     </TooltipContent>
                     <ChildContent>
-                        <DefaultButton>Without break</DefaultButton>
+                        <DefaultButton>Without beak</DefaultButton>
                     </ChildContent>
                 </TooltipHost>
             </Demo>

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/TooltipPage.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/TooltipPage.md
@@ -29,12 +29,30 @@
     <div>
         <div class="subSection">
             <Demo Header="Tooltip" Key="0" MetadataPath="TooltipPage">
-               <TooltipHost>
+                <TooltipHost>
                     <TooltipContent>
                         Hey, look here!
                     </TooltipContent>
                     <ChildContent>
                         <DefaultButton>Hover to see a tooltip</DefaultButton>
+                    </ChildContent>
+                </TooltipHost>
+                
+                <TooltipHost GapSpace="10">
+                    <TooltipContent>
+                        Hey, look here!
+                    </TooltipContent>
+                    <ChildContent>
+                        <DefaultButton>With gap</DefaultButton>
+                    </ChildContent>
+                </TooltipHost>
+                
+                <TooltipHost IsBreakVisible="false">
+                    <TooltipContent>
+                        Hey, look here!
+                    </TooltipContent>
+                    <ChildContent>
+                        <DefaultButton>Without break</DefaultButton>
                     </ChildContent>
                 </TooltipHost>
             </Demo>

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/TooltipPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/TooltipPage.razor
@@ -47,12 +47,12 @@
                     </ChildContent>
                 </TooltipHost>
                 
-                <TooltipHost IsBreakVisible="false">
+                <TooltipHost IsBeakVisible="false">
                     <TooltipContent>
                         Hey, look here!
                     </TooltipContent>
                     <ChildContent>
-                        <DefaultButton>Without break</DefaultButton>
+                        <DefaultButton>Without beak</DefaultButton>
                     </ChildContent>
                 </TooltipHost>
             </Demo>

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/TooltipPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/TooltipPage.razor
@@ -29,12 +29,30 @@
     <div>
         <div class="subSection">
             <Demo Header="Tooltip" Key="0" MetadataPath="TooltipPage">
-               <TooltipHost>
+                <TooltipHost>
                     <TooltipContent>
                         Hey, look here!
                     </TooltipContent>
                     <ChildContent>
                         <DefaultButton>Hover to see a tooltip</DefaultButton>
+                    </ChildContent>
+                </TooltipHost>
+                
+                <TooltipHost GapSpace="10">
+                    <TooltipContent>
+                        Hey, look here!
+                    </TooltipContent>
+                    <ChildContent>
+                        <DefaultButton>With gap</DefaultButton>
+                    </ChildContent>
+                </TooltipHost>
+                
+                <TooltipHost IsBreakVisible="false">
+                    <TooltipContent>
+                        Hey, look here!
+                    </TooltipContent>
+                    <ChildContent>
+                        <DefaultButton>Without break</DefaultButton>
                     </ChildContent>
                 </TooltipHost>
             </Demo>

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor
@@ -8,9 +8,9 @@
          DirectionalHint=@DirectionalHint
          Style=@($"{Style}")
          BeakWidth=@BeakWidth
-         GapSpace="0"
+         GapSpace="@GapSpace"
          DoNotLayer="false"
-         IsBeakVisible="true">
+         IsBeakVisible="@IsBreakVisible">
     <div class="ms-Tooltip-content"
          @onmouseenter=@OnMouseEnter
          @onmouseleave=@OnMouseLeave

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor
@@ -10,7 +10,7 @@
          BeakWidth=@BeakWidth
          GapSpace="@GapSpace"
          DoNotLayer="false"
-         IsBeakVisible="@IsBreakVisible">
+         IsBeakVisible="@IsBeakVisible">
     <div class="ms-Tooltip-content"
          @onmouseenter=@OnMouseEnter
          @onmouseleave=@OnMouseLeave

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor.cs
@@ -16,7 +16,7 @@ namespace BlazorFluentUI
         [Parameter] public EventCallback<EventArgs> OnMouseEnter { get; set; }
         [Parameter] public EventCallback<EventArgs> OnMouseLeave { get; set; }
         [Parameter] public int GapSpace { get; set; } = 0;
-        [Parameter] public bool IsBreakVisible { get; set; } = true;
+        [Parameter] public bool IsBeakVisible { get; set; } = true;
 
         private ICollection<IRule> TooltipLocalRules { get; set; } = new List<IRule>();
 

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/Tooltip.razor.cs
@@ -15,6 +15,8 @@ namespace BlazorFluentUI
         [Parameter] public double MaxWidth { get; set; } = 364;
         [Parameter] public EventCallback<EventArgs> OnMouseEnter { get; set; }
         [Parameter] public EventCallback<EventArgs> OnMouseLeave { get; set; }
+        [Parameter] public int GapSpace { get; set; } = 0;
+        [Parameter] public bool IsBreakVisible { get; set; } = true;
 
         private ICollection<IRule> TooltipLocalRules { get; set; } = new List<IRule>();
 

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor
@@ -17,7 +17,9 @@
         <Tooltip DirectionalHint=@DirectionalHint
                  FabricComponentTarget=@TargetElement
                  OnMouseLeave=@OnTooltipMouseEnter
-                 OnMouseEnter=@OnTooltipMouseLeave>
+                 OnMouseEnter=@OnTooltipMouseLeave
+                 GapSpace=@GapSpace
+                 IsBreakVisible=@IsBreakVisible>
             @TooltipContent
         </Tooltip>
     }

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor
@@ -19,7 +19,7 @@
                  OnMouseLeave=@OnTooltipMouseEnter
                  OnMouseEnter=@OnTooltipMouseLeave
                  GapSpace=@GapSpace
-                 IsBreakVisible=@IsBreakVisible>
+                 IsBeakVisible=@IsBeakVisible>
             @TooltipContent
         </Tooltip>
     }

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor.cs
@@ -23,6 +23,9 @@ namespace BlazorFluentUI
         [Parameter] public FluentUIComponentBase? Parent { get; set; }
         [Parameter] public bool SetAriaDescribedBy { get; set; }
         [Parameter] public RenderFragment? TooltipContent { get; set; }
+        
+        [Parameter] public int GapSpace { get; set; } = 0;
+        [Parameter] public bool IsBreakVisible { get; set; } = true;
 
         protected FluentUIComponentBase? TargetElement;
         protected bool ShowTooltip;

--- a/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/Tooltip/TooltipHost.razor.cs
@@ -25,7 +25,7 @@ namespace BlazorFluentUI
         [Parameter] public RenderFragment? TooltipContent { get; set; }
         
         [Parameter] public int GapSpace { get; set; } = 0;
-        [Parameter] public bool IsBreakVisible { get; set; } = true;
+        [Parameter] public bool IsBeakVisible { get; set; } = true;
 
         protected FluentUIComponentBase? TargetElement;
         protected bool ShowTooltip;


### PR DESCRIPTION
Allows for better customizability for situations where the beak is not desired and gapspace when you show a tooltip on a item that is only visible during hover which would cause weird display flickers.