### PR TITLE
Fixes for DetailsList

### DIFF
--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListAutoGroupedPage.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListAutoGroupedPage.md
@@ -69,12 +69,12 @@
     System.Collections.Generic.List<DataItem> dataSource = new();
     int count = 0;
 
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> columnsSource = new();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> columnsSource = new();
 
     DetailsListAuto<DataItem>? detailsList;
 
     string filter = "";
-    DetailsRowColumn<DataItem>? descriptionColumn;
+    IDetailsRowColumn<DataItem>? descriptionColumn;
 
     protected override void OnInitialized()
     {

--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListAutoPage.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListAutoPage.md
@@ -36,7 +36,7 @@
                 </Stack>
                 <TextField Label="Filter Description"
                            Value=@filter
-                           OnInput=@(val => { filter = val; descriptionColumn!.FilterPredicate = prop => prop.Contains(filter); }) />
+                           OnInput=@(val => { filter = val; descriptionColumn!.FilterPredicate = prop => (prop as string).Contains(filter); }) />
                 <div data-is-scrollable="true" style="height:400px;overflow-y:auto;">
                     <DetailsListAuto  ItemsSource="dataSource"
                                      IsVirtualizing=@isVirtualizing
@@ -98,8 +98,8 @@
     int count = 0;
 
     // We're creating another container for the column array that needs to be defined to show columns in DetailsList.
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> columnsSource = new ();
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> fixedColumnsSource = new ();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> columnsSource = new ();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> fixedColumnsSource = new ();
 
     string filter = "";
     DetailsRowColumn<DataItem, string>? descriptionColumn;

--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListGroupedPage.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListGroupedPage.md
@@ -65,8 +65,8 @@
     public System.ComponentModel.BindingList<GroupedDataItem> ReadonlyList = new System.ComponentModel.BindingList<GroupedDataItem>();
     int count = 0;
 
-    SourceCache<DetailsRowColumn<GroupedDataItem>, string> columnsSource = new SourceCache<DetailsRowColumn<GroupedDataItem>, string>(x => x.Key!);
-    public ReadOnlyObservableCollection<DetailsRowColumn<GroupedDataItem>>? ReadonlyColumns;
+    SourceCache<IDetailsRowColumn<GroupedDataItem>, string> columnsSource = new SourceCache<IDetailsRowColumn<GroupedDataItem>, string>(x => x.Key!);
+    public ReadOnlyObservableCollection<IDetailsRowColumn<GroupedDataItem>>? ReadonlyColumns;
 
     DetailsList<GroupedDataItem>? detailsList;
 
@@ -134,7 +134,7 @@
             .Subscribe();
 
         columnsSource.Connect()
-            .Sort(SortExpressionComparer<DetailsRowColumn<GroupedDataItem>>.Ascending(x => x.Index))
+            .Sort(SortExpressionComparer<IDetailsRowColumn<GroupedDataItem>>.Ascending(x => x.Index))
             .Bind(out ReadonlyColumns)
             .Do(_ => StateHasChanged())  //when a column is clicked, that column's details will update... but other columns won't.  Need to call StateHasChanged to redraw all.
             .Subscribe();
@@ -142,7 +142,7 @@
         base.OnInitialized();
     }
 
-    private void OnColumnClick(DetailsRowColumn<GroupedDataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<GroupedDataItem> column)
     {
 
         if (column.IsSorted)

--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListPage.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListPage.md
@@ -84,8 +84,8 @@
     int count = 0;
 
     // We're creating another container for the column array that needs to be defined to show columns in DetailsList.
-    SourceCache<DetailsRowColumn<DataItem>, string> columnsSource = new SourceCache<DetailsRowColumn<DataItem>, string>(x => x.Key!);
-    public ReadOnlyObservableCollection<DetailsRowColumn<DataItem>>? ReadonlyColumns;
+    SourceCache<IDetailsRowColumn<DataItem>, string> columnsSource = new SourceCache<IDetailsRowColumn<DataItem>, string>(x => x.Key!);
+    public ReadOnlyObservableCollection<IDetailsRowColumn<DataItem>>? ReadonlyColumns;
 
     // This class just holds some properties that make it easier to sort and filter data.
     ObservableDataContainer dataContainer = new ObservableDataContainer();
@@ -195,7 +195,7 @@
             // automatically.  We also have a Do operator in there that calls a StateHasChanged whenever the contents are changed or if
             // the Sort expression changes.
             columnsSource.Connect()
-                    .Sort(SortExpressionComparer<DetailsRowColumn<DataItem>>.Ascending(x => x.Index))
+                    .Sort(SortExpressionComparer<IDetailsRowColumn<DataItem>>.Ascending(x => x.Index))
                     .Bind(out ReadonlyColumns)
                     .Do(_ => InvokeAsync(StateHasChanged))  //when a column is clicked, that column's details will update... but other columns won't.  Need to call StateHasChanged to redraw all.
                     .Subscribe();
@@ -208,7 +208,7 @@
     // This callback is fired when a column header is clicked.  We go through each column item and change their sort properties.
     // To update the changes in our UI, we just use the `AddOrUpdate` method and DynamicData will make the changes in the bound
     // list.
-    private void OnColumnClick(DetailsRowColumn<DataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<DataItem> column)
     {
         if (column.IsSorted)
         {

--- a/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListPageBasic.md
+++ b/Demo/BlazorFluentUI.Demo.Client/wwwroot/md/DetailsListPageBasic.md
@@ -58,8 +58,8 @@
 
     Selection<DataItem> selection = new Selection<DataItem>();
 
-    public System.Collections.Generic.List<DetailsRowColumn<DataItem>> Columns = new();
-    public System.Collections.Generic.List<DetailsRowColumn<DataItem>> CustomColumns = new();
+    public System.Collections.Generic.List<IDetailsRowColumn<DataItem>> Columns = new();
+    public System.Collections.Generic.List<IDetailsRowColumn<DataItem>> CustomColumns = new();
 
     protected override void OnInitialized()
     {
@@ -71,7 +71,7 @@
         // Do NOT use the DetailsRowColumn with two generic parameters.  It does not create an expression that can be used with DynamicAccessor.
         CustomColumns.Add(new DetailsRowColumn<DataItem>("Key", x => x.KeyNumber) { MaxWidth = 70, Index = 0 });
         CustomColumns.Add(new DetailsRowColumn<DataItem>("Name", x => x.DisplayName!) { Index = 1, MaxWidth = 150, OnColumnClick = this.OnColumnClick, IsResizable = true });
-        CustomColumns.Add(new DetailsRowColumn<DataItem>("Notes", x => x.Description!)
+        CustomColumns.Add(new DetailsRowColumn<DataItem,DataItem>("Notes", x => x)
         {
             Index = 2,
             // Two issues:
@@ -80,16 +80,17 @@
             //     to the original property because DynamicAccessor creates a setter from your original getter (the field selector).
             // 2.  Blazor cannot do type conversions directly with binding yet.  Since the output (of DynamicAccessor's Value) is an object, we need to manually 
             //     create the callback that sets the Value from the change.  We can't use generics (easily) because they would all have to be the same type.
-            ColumnItemTemplate = description => builder =>
-            {
-                builder.OpenComponent<TextField>(0);
-                builder.AddAttribute(1, "Value", description.Value);
-                builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, changedText =>
-                {
-                    description.Value = changedText;
-                }));
-                builder.CloseComponent();
-            }
+            ColumnItemTemplate = obj => @<TextField @bind-Value="obj.Description" @bind-Value:event="OnChange"/>
+            //ColumnItemTemplate = description => builder =>
+            //{
+            //    builder.OpenComponent<TextField>(0);
+            //    builder.AddAttribute(1, "Value", description.Value);
+            //    builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, changedText =>
+            //    {
+            //        description.Value = changedText;
+            //    }));
+            //    builder.CloseComponent();
+            //}
 
         });
 
@@ -105,7 +106,7 @@
         base.OnInitialized();
     }
 
-    private void OnColumnClick(DetailsRowColumn<DataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<DataItem> column)
     {
         // since we're creating a new list, we need to make a copy of what was previously selected
         var selected = selection.GetSelection();

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListAutoGroupedPage.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListAutoGroupedPage.md
@@ -69,12 +69,12 @@
     System.Collections.Generic.List<DataItem> dataSource = new();
     int count = 0;
 
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> columnsSource = new();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> columnsSource = new();
 
     DetailsListAuto<DataItem>? detailsList;
 
     string filter = "";
-    DetailsRowColumn<DataItem>? descriptionColumn;
+    IDetailsRowColumn<DataItem>? descriptionColumn;
 
     protected override void OnInitialized()
     {

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListAutoPage.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListAutoPage.md
@@ -36,7 +36,7 @@
                 </Stack>
                 <TextField Label="Filter Description"
                            Value=@filter
-                           OnInput=@(val => { filter = val; descriptionColumn!.FilterPredicate = prop => prop.Contains(filter); }) />
+                           OnInput=@(val => { filter = val; descriptionColumn!.FilterPredicate = prop => (prop as string).Contains(filter); }) />
                 <div data-is-scrollable="true" style="height:400px;overflow-y:auto;">
                     <DetailsListAuto  ItemsSource="dataSource"
                                      IsVirtualizing=@isVirtualizing
@@ -98,8 +98,8 @@
     int count = 0;
 
     // We're creating another container for the column array that needs to be defined to show columns in DetailsList.
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> columnsSource = new ();
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> fixedColumnsSource = new ();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> columnsSource = new ();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> fixedColumnsSource = new ();
 
     string filter = "";
     DetailsRowColumn<DataItem, string>? descriptionColumn;

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListGroupedPage.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListGroupedPage.md
@@ -65,8 +65,8 @@
     public System.ComponentModel.BindingList<GroupedDataItem> ReadonlyList = new System.ComponentModel.BindingList<GroupedDataItem>();
     int count = 0;
 
-    SourceCache<DetailsRowColumn<GroupedDataItem>, string> columnsSource = new SourceCache<DetailsRowColumn<GroupedDataItem>, string>(x => x.Key!);
-    public ReadOnlyObservableCollection<DetailsRowColumn<GroupedDataItem>>? ReadonlyColumns;
+    SourceCache<IDetailsRowColumn<GroupedDataItem>, string> columnsSource = new SourceCache<IDetailsRowColumn<GroupedDataItem>, string>(x => x.Key!);
+    public ReadOnlyObservableCollection<IDetailsRowColumn<GroupedDataItem>>? ReadonlyColumns;
 
     DetailsList<GroupedDataItem>? detailsList;
 
@@ -134,7 +134,7 @@
             .Subscribe();
 
         columnsSource.Connect()
-            .Sort(SortExpressionComparer<DetailsRowColumn<GroupedDataItem>>.Ascending(x => x.Index))
+            .Sort(SortExpressionComparer<IDetailsRowColumn<GroupedDataItem>>.Ascending(x => x.Index))
             .Bind(out ReadonlyColumns)
             .Do(_ => StateHasChanged())  //when a column is clicked, that column's details will update... but other columns won't.  Need to call StateHasChanged to redraw all.
             .Subscribe();
@@ -142,7 +142,7 @@
         base.OnInitialized();
     }
 
-    private void OnColumnClick(DetailsRowColumn<GroupedDataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<GroupedDataItem> column)
     {
 
         if (column.IsSorted)

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListPage.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListPage.md
@@ -84,8 +84,8 @@
     int count = 0;
 
     // We're creating another container for the column array that needs to be defined to show columns in DetailsList.
-    SourceCache<DetailsRowColumn<DataItem>, string> columnsSource = new SourceCache<DetailsRowColumn<DataItem>, string>(x => x.Key!);
-    public ReadOnlyObservableCollection<DetailsRowColumn<DataItem>>? ReadonlyColumns;
+    SourceCache<IDetailsRowColumn<DataItem>, string> columnsSource = new SourceCache<IDetailsRowColumn<DataItem>, string>(x => x.Key!);
+    public ReadOnlyObservableCollection<IDetailsRowColumn<DataItem>>? ReadonlyColumns;
 
     // This class just holds some properties that make it easier to sort and filter data.
     ObservableDataContainer dataContainer = new ObservableDataContainer();
@@ -195,7 +195,7 @@
             // automatically.  We also have a Do operator in there that calls a StateHasChanged whenever the contents are changed or if
             // the Sort expression changes.
             columnsSource.Connect()
-                    .Sort(SortExpressionComparer<DetailsRowColumn<DataItem>>.Ascending(x => x.Index))
+                    .Sort(SortExpressionComparer<IDetailsRowColumn<DataItem>>.Ascending(x => x.Index))
                     .Bind(out ReadonlyColumns)
                     .Do(_ => InvokeAsync(StateHasChanged))  //when a column is clicked, that column's details will update... but other columns won't.  Need to call StateHasChanged to redraw all.
                     .Subscribe();
@@ -208,7 +208,7 @@
     // This callback is fired when a column header is clicked.  We go through each column item and change their sort properties.
     // To update the changes in our UI, we just use the `AddOrUpdate` method and DynamicData will make the changes in the bound
     // list.
-    private void OnColumnClick(DetailsRowColumn<DataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<DataItem> column)
     {
         if (column.IsSorted)
         {

--- a/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListPageBasic.md
+++ b/Demo/BlazorFluentUI.Demo.Server/wwwroot/md/DetailsListPageBasic.md
@@ -58,8 +58,8 @@
 
     Selection<DataItem> selection = new Selection<DataItem>();
 
-    public System.Collections.Generic.List<DetailsRowColumn<DataItem>> Columns = new();
-    public System.Collections.Generic.List<DetailsRowColumn<DataItem>> CustomColumns = new();
+    public System.Collections.Generic.List<IDetailsRowColumn<DataItem>> Columns = new();
+    public System.Collections.Generic.List<IDetailsRowColumn<DataItem>> CustomColumns = new();
 
     protected override void OnInitialized()
     {
@@ -71,7 +71,7 @@
         // Do NOT use the DetailsRowColumn with two generic parameters.  It does not create an expression that can be used with DynamicAccessor.
         CustomColumns.Add(new DetailsRowColumn<DataItem>("Key", x => x.KeyNumber) { MaxWidth = 70, Index = 0 });
         CustomColumns.Add(new DetailsRowColumn<DataItem>("Name", x => x.DisplayName!) { Index = 1, MaxWidth = 150, OnColumnClick = this.OnColumnClick, IsResizable = true });
-        CustomColumns.Add(new DetailsRowColumn<DataItem>("Notes", x => x.Description!)
+        CustomColumns.Add(new DetailsRowColumn<DataItem,DataItem>("Notes", x => x)
         {
             Index = 2,
             // Two issues:
@@ -80,16 +80,17 @@
             //     to the original property because DynamicAccessor creates a setter from your original getter (the field selector).
             // 2.  Blazor cannot do type conversions directly with binding yet.  Since the output (of DynamicAccessor's Value) is an object, we need to manually 
             //     create the callback that sets the Value from the change.  We can't use generics (easily) because they would all have to be the same type.
-            ColumnItemTemplate = description => builder =>
-            {
-                builder.OpenComponent<TextField>(0);
-                builder.AddAttribute(1, "Value", description.Value);
-                builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, changedText =>
-                {
-                    description.Value = changedText;
-                }));
-                builder.CloseComponent();
-            }
+            ColumnItemTemplate = obj => @<TextField @bind-Value="obj.Description" @bind-Value:event="OnChange"/>
+            //ColumnItemTemplate = description => builder =>
+            //{
+            //    builder.OpenComponent<TextField>(0);
+            //    builder.AddAttribute(1, "Value", description.Value);
+            //    builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, changedText =>
+            //    {
+            //        description.Value = changedText;
+            //    }));
+            //    builder.CloseComponent();
+            //}
 
         });
 
@@ -105,7 +106,7 @@
         base.OnInitialized();
     }
 
-    private void OnColumnClick(DetailsRowColumn<DataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<DataItem> column)
     {
         // since we're creating a new list, we need to make a copy of what was previously selected
         var selected = selection.GetSelection();

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListAutoGroupedPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListAutoGroupedPage.razor
@@ -69,12 +69,12 @@
     System.Collections.Generic.List<DataItem> dataSource = new();
     int count = 0;
 
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> columnsSource = new();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> columnsSource = new();
 
     DetailsListAuto<DataItem>? detailsList;
 
     string filter = "";
-    DetailsRowColumn<DataItem>? descriptionColumn;
+    IDetailsRowColumn<DataItem>? descriptionColumn;
 
     protected override void OnInitialized()
     {

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListAutoPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListAutoPage.razor
@@ -36,7 +36,7 @@
                 </Stack>
                 <TextField Label="Filter Description"
                            Value=@filter
-                           OnInput=@(val => { filter = val; descriptionColumn!.FilterPredicate = prop => prop.Contains(filter); }) />
+                           OnInput=@(val => { filter = val; descriptionColumn!.FilterPredicate = prop => (prop as string).Contains(filter); }) />
                 <div data-is-scrollable="true" style="height:400px;overflow-y:auto;">
                     <DetailsListAuto  ItemsSource="dataSource"
                                      IsVirtualizing=@isVirtualizing
@@ -98,8 +98,8 @@
     int count = 0;
 
     // We're creating another container for the column array that needs to be defined to show columns in DetailsList.
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> columnsSource = new ();
-    System.Collections.Generic.List<DetailsRowColumn<DataItem>> fixedColumnsSource = new ();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> columnsSource = new ();
+    System.Collections.Generic.List<IDetailsRowColumn<DataItem>> fixedColumnsSource = new ();
 
     string filter = "";
     DetailsRowColumn<DataItem, string>? descriptionColumn;

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListGroupedPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListGroupedPage.razor
@@ -65,8 +65,8 @@
     public System.ComponentModel.BindingList<GroupedDataItem> ReadonlyList = new System.ComponentModel.BindingList<GroupedDataItem>();
     int count = 0;
 
-    SourceCache<DetailsRowColumn<GroupedDataItem>, string> columnsSource = new SourceCache<DetailsRowColumn<GroupedDataItem>, string>(x => x.Key!);
-    public ReadOnlyObservableCollection<DetailsRowColumn<GroupedDataItem>>? ReadonlyColumns;
+    SourceCache<IDetailsRowColumn<GroupedDataItem>, string> columnsSource = new SourceCache<IDetailsRowColumn<GroupedDataItem>, string>(x => x.Key!);
+    public ReadOnlyObservableCollection<IDetailsRowColumn<GroupedDataItem>>? ReadonlyColumns;
 
     DetailsList<GroupedDataItem>? detailsList;
 
@@ -134,7 +134,7 @@
             .Subscribe();
 
         columnsSource.Connect()
-            .Sort(SortExpressionComparer<DetailsRowColumn<GroupedDataItem>>.Ascending(x => x.Index))
+            .Sort(SortExpressionComparer<IDetailsRowColumn<GroupedDataItem>>.Ascending(x => x.Index))
             .Bind(out ReadonlyColumns)
             .Do(_ => StateHasChanged())  //when a column is clicked, that column's details will update... but other columns won't.  Need to call StateHasChanged to redraw all.
             .Subscribe();
@@ -142,7 +142,7 @@
         base.OnInitialized();
     }
 
-    private void OnColumnClick(DetailsRowColumn<GroupedDataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<GroupedDataItem> column)
     {
 
         if (column.IsSorted)

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPage.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPage.razor
@@ -84,8 +84,8 @@
     int count = 0;
 
     // We're creating another container for the column array that needs to be defined to show columns in DetailsList.
-    SourceCache<DetailsRowColumn<DataItem>, string> columnsSource = new SourceCache<DetailsRowColumn<DataItem>, string>(x => x.Key!);
-    public ReadOnlyObservableCollection<DetailsRowColumn<DataItem>>? ReadonlyColumns;
+    SourceCache<IDetailsRowColumn<DataItem>, string> columnsSource = new SourceCache<IDetailsRowColumn<DataItem>, string>(x => x.Key!);
+    public ReadOnlyObservableCollection<IDetailsRowColumn<DataItem>>? ReadonlyColumns;
 
     // This class just holds some properties that make it easier to sort and filter data.
     ObservableDataContainer dataContainer = new ObservableDataContainer();
@@ -195,7 +195,7 @@
             // automatically.  We also have a Do operator in there that calls a StateHasChanged whenever the contents are changed or if
             // the Sort expression changes.
             columnsSource.Connect()
-                    .Sort(SortExpressionComparer<DetailsRowColumn<DataItem>>.Ascending(x => x.Index))
+                    .Sort(SortExpressionComparer<IDetailsRowColumn<DataItem>>.Ascending(x => x.Index))
                     .Bind(out ReadonlyColumns)
                     .Do(_ => InvokeAsync(StateHasChanged))  //when a column is clicked, that column's details will update... but other columns won't.  Need to call StateHasChanged to redraw all.
                     .Subscribe();
@@ -208,7 +208,7 @@
     // This callback is fired when a column header is clicked.  We go through each column item and change their sort properties.
     // To update the changes in our UI, we just use the `AddOrUpdate` method and DynamicData will make the changes in the bound
     // list.
-    private void OnColumnClick(DetailsRowColumn<DataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<DataItem> column)
     {
         if (column.IsSorted)
         {

--- a/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPageBasic.razor
+++ b/Demo/BlazorFluentUI.Demo.Shared/Pages/DetailsListPageBasic.razor
@@ -58,8 +58,8 @@
 
     Selection<DataItem> selection = new Selection<DataItem>();
 
-    public System.Collections.Generic.List<DetailsRowColumn<DataItem>> Columns = new();
-    public System.Collections.Generic.List<DetailsRowColumn<DataItem>> CustomColumns = new();
+    public System.Collections.Generic.List<IDetailsRowColumn<DataItem>> Columns = new();
+    public System.Collections.Generic.List<IDetailsRowColumn<DataItem>> CustomColumns = new();
 
     protected override void OnInitialized()
     {
@@ -71,7 +71,7 @@
         // Do NOT use the DetailsRowColumn with two generic parameters.  It does not create an expression that can be used with DynamicAccessor.
         CustomColumns.Add(new DetailsRowColumn<DataItem>("Key", x => x.KeyNumber) { MaxWidth = 70, Index = 0 });
         CustomColumns.Add(new DetailsRowColumn<DataItem>("Name", x => x.DisplayName!) { Index = 1, MaxWidth = 150, OnColumnClick = this.OnColumnClick, IsResizable = true });
-        CustomColumns.Add(new DetailsRowColumn<DataItem>("Notes", x => x.Description!)
+        CustomColumns.Add(new DetailsRowColumn<DataItem,DataItem>("Notes", x => x)
         {
             Index = 2,
             // Two issues:
@@ -80,16 +80,17 @@
             //     to the original property because DynamicAccessor creates a setter from your original getter (the field selector).
             // 2.  Blazor cannot do type conversions directly with binding yet.  Since the output (of DynamicAccessor's Value) is an object, we need to manually 
             //     create the callback that sets the Value from the change.  We can't use generics (easily) because they would all have to be the same type.
-            ColumnItemTemplate = description => builder =>
-            {
-                builder.OpenComponent<TextField>(0);
-                builder.AddAttribute(1, "Value", description.Value);
-                builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, changedText =>
-                {
-                    description.Value = changedText;
-                }));
-                builder.CloseComponent();
-            }
+            ColumnItemTemplate = obj => @<TextField @bind-Value="obj.Description" @bind-Value:event="OnChange"/>
+            //ColumnItemTemplate = description => builder =>
+            //{
+            //    builder.OpenComponent<TextField>(0);
+            //    builder.AddAttribute(1, "Value", description.Value);
+            //    builder.AddAttribute(2, "ValueChanged", EventCallback.Factory.Create<string>(this, changedText =>
+            //    {
+            //        description.Value = changedText;
+            //    }));
+            //    builder.CloseComponent();
+            //}
 
         });
 
@@ -105,7 +106,7 @@
         base.OnInitialized();
     }
 
-    private void OnColumnClick(DetailsRowColumn<DataItem> column)
+    private void OnColumnClick(IDetailsRowColumn<DataItem> column)
     {
         // since we're creating a new list, we need to make a copy of what was previously selected
         var selected = selection.GetSelection();

--- a/src/BlazorFluentUI.CoreComponents/DetailsRow/ColumnMeasureInfo.cs
+++ b/src/BlazorFluentUI.CoreComponents/DetailsRow/ColumnMeasureInfo.cs
@@ -9,7 +9,7 @@ namespace BlazorFluentUI
     public class ColumnMeasureInfo<TItem>
     {
         public int Index { get; set; }
-        public DetailsRowColumn<TItem>? Column { get; set; }
+        public IDetailsRowColumn<TItem>? Column { get; set; }
         public Action<double>? OnMeasureDone { get; set; }
     }
 }

--- a/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRow.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRow.razor.cs
@@ -20,7 +20,7 @@ namespace BlazorFluentUI
         public bool AnySelected { get; set; }
 
         [Parameter]
-        public IEnumerable<DetailsRowColumn<TItem>>? Columns { get; set; }
+        public IEnumerable<IDetailsRowColumn<TItem>>? Columns { get; set; }
 
         [Parameter]
         public bool Compact { get; set; }
@@ -208,7 +208,7 @@ namespace BlazorFluentUI
         {
             if (Columns != null)
             {
-                DetailsRowColumn<TItem>? column = Columns.ElementAt(index);
+                IDetailsRowColumn<TItem>? column = Columns.ElementAt(index);
                 column.MinWidth = 0;
                 column.MaxWidth = 999999;
                 column.CalculatedWidth = double.NaN;

--- a/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRowColumn.cs
+++ b/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRowColumn.cs
@@ -3,22 +3,38 @@ using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reactive.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace BlazorFluentUI
 {
-    public class DetailsRowColumn<TItem, TProp> : DetailsRowColumn<TItem>
+    public class DetailsRowColumn<TItem, TProp> : IDetailsRowColumn<TItem>
     {
-        private Func<TProp, bool>? _filterPredicate;
-        public new Func<TProp, bool>? FilterPredicate
+
+        private Func<object, bool>? _filterPredicate;
+        public Func<object, bool>? FilterPredicate
         {
             get => _filterPredicate;
             set
             {
-                base.FilterPredicate = x => FilterPredicate == null || FilterPredicate((TProp)x);
                 _filterPredicate = value;
+                OnPropertyChanged();
+                OnPropertyChanged("InternalFilterPredicate");
             }
         }
+
+        //private Func<TProp, bool>? _filterPredicate;
+        //public new Func<TProp, bool>? FilterPredicate
+        //{
+        //    get => _filterPredicate;
+        //    set
+        //    {
+        //       // IDetailsRowColumn<TItem>.FilterPredicate = x => FilterPredicate == null || FilterPredicate((TProp)x);
+        //        _filterPredicate = value;
+        //        OnPropertyChanged();
+        //        OnPropertyChanged("InternalFilterPredicate");
+        //    }
+        //}
 
         public DetailsRowColumn()
         {
@@ -37,10 +53,80 @@ namespace BlazorFluentUI
 
             Initialize();
         }
+
+        public string? AriaLabel { get; set; }
+        public double CalculatedWidth { get; set; } = double.NaN;
+        public ColumnActionsMode ColumnActionsMode { get; set; } = ColumnActionsMode.Clickable;
+        public RenderFragment<TItem>? ColumnItemTemplate { get; set; }
+
+        object? IDetailsRowColumn<TItem>.InternalColumnItemTemplate => ColumnItemTemplate;
+
+        public Func<TItem, object>? FieldSelector { get; set; }
+
+        Expression<Func<TItem, object>>? IDetailsRowColumn<TItem>.FieldSelectorExpression { get => null; set => _=value; }
+
+        public string? FilterAriaLabel { get; set; }
+
+        
+        public string? GroupAriaLabel { get; set; }
+        public string? IconClassName { get; set; }
+        public string? IconName { get; set; }
+        public string? IconSrc { get; set; }
+        /// <summary>
+        /// Forces columns to be in a particular order.  Useful for libraries (like DynamicData) that don't maintain order of collections internally.
+        /// </summary>
+        public int Index { get; set; }
+        public bool IsCollapsible { get; set; }
+        public bool IsFiltered { get; set; }
+        public bool IsGrouped { get; set; }
+        public bool IsIconOnly { get; set; }
+        public bool IsMenuOpen { get; set; }
+        public bool IsMultiline { get; set; }
+        public bool IsPadded { get; set; }
+        public bool IsResizable { get; set; }
+        public bool IsRowHeader { get; set; }  // only one can be set, it's for the "role" (and a style is set, too)
+
+        private bool _isSorted;
+        public bool IsSorted { get => _isSorted; set { if (_isSorted == value) return; else { _isSorted = value; OnPropertyChanged(); } } }
+
+        private bool _isSortedDescending;
+        public bool IsSortedDescending { get => _isSortedDescending; set { if (_isSortedDescending == value) return; else { _isSortedDescending = value; OnPropertyChanged(); } } }
+        public string? Key { get; set; }
+        public double MaxWidth { get; set; } = 300;
+        public double MinWidth { get; set; } = 100;
+        public string? Name { get; set; }
+        public Action<IDetailsRowColumn<TItem>>? OnColumnClick { get; set; }
+        public Action<IDetailsRowColumn<TItem>>? OnColumnContextMenu { get; set; }
+        public Type? PropType { get; protected set; }
+        public string? SortedAscendingAriaLabel { get; set; }
+        public string? SortedDescendingAriaLabel { get; set; }
+        public Type? Type { get; set; }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public IObservable<PropertyChangedEventArgs>? WhenPropertyChanged { get; private set; }
+        
+        protected void Initialize()
+        {
+            WhenPropertyChanged = Observable.FromEvent<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+              handler =>
+              {
+                  void changed(object? sender, PropertyChangedEventArgs e) => handler(e);
+                  return changed;
+              },
+              handler => PropertyChanged += handler,
+              handler => PropertyChanged -= handler);
+        }
     }
 
-    public class DetailsRowColumn<TItem>
+    public class DetailsRowColumn<TItem> : IDetailsRowColumn<TItem>
     {
+
+
         public Expression<Func<TItem, object>>? FieldSelectorExpression { get; set; }
 
         public string? AriaLabel { get; set; }
@@ -48,17 +134,22 @@ namespace BlazorFluentUI
         public ColumnActionsMode ColumnActionsMode { get; set; } = ColumnActionsMode.Clickable;
         public RenderFragment<DynamicAccessor<TItem>>? ColumnItemTemplate { get; set; }
 
+
+        object? IDetailsRowColumn<TItem>.InternalColumnItemTemplate => ColumnItemTemplate;
+
         public Func<TItem, object>? FieldSelector { get; set; }
         public string? FilterAriaLabel { get; set; }
 
+                
         private Func<object, bool>? _filterPredicate;
         public Func<object, bool>? FilterPredicate
         {
             get => _filterPredicate;
             set
             {
-                _filterPredicate = value; OnPropertyChanged();
-                //if (_filterPredicate == value) return; else { _filterPredicate = value; OnPropertyChanged(); } 
+                _filterPredicate = value; 
+                OnPropertyChanged();
+                OnPropertyChanged("InternalFilterPredicate");
             }
         }
 
@@ -89,8 +180,8 @@ namespace BlazorFluentUI
         public double MaxWidth { get; set; } = 300;
         public double MinWidth { get; set; } = 100;
         public string? Name { get; set; }
-        public Action<DetailsRowColumn<TItem>>? OnColumnClick { get; set; }
-        public Action<DetailsRowColumn<TItem>>? OnColumnContextMenu { get; set; }
+        public Action<IDetailsRowColumn<TItem>>? OnColumnClick { get; set; }
+        public Action<IDetailsRowColumn<TItem>>? OnColumnContextMenu { get; set; }
         public Type? PropType { get; protected set; }
         public string? SortedAscendingAriaLabel { get; set; }
         public string? SortedDescendingAriaLabel { get; set; }
@@ -119,6 +210,7 @@ namespace BlazorFluentUI
         }
 
         public IObservable<PropertyChangedEventArgs>? WhenPropertyChanged { get; private set; }
+
 
         protected void Initialize()
         {

--- a/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRowFields.razor
+++ b/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRowFields.razor
@@ -28,9 +28,17 @@
              style=@($"width:{width};padding-left:{CellLeftPadding}px;")
 
              >
-            @if (column.ColumnItemTemplate != null)
+            @if (column.InternalColumnItemTemplate != null && column.FieldSelectorExpression != null)
             {
-                @column.ColumnItemTemplate(new DynamicAccessor<TItem>(Item!, column.FieldSelectorExpression!))
+                var fragment = (column.InternalColumnItemTemplate as RenderFragment<DynamicAccessor<TItem>>);
+                if (fragment != null)
+                    @fragment(new DynamicAccessor<TItem>(Item!, column.FieldSelectorExpression!))
+            }
+            else if (column.InternalColumnItemTemplate != null && column.FieldSelectorExpression == null)
+            {
+                var fragment = (column.InternalColumnItemTemplate as RenderFragment<TItem>);
+                if (fragment != null)
+                    @fragment(Item!)
             }
             else
             {

--- a/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRowFields.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/DetailsRow/DetailsRowFields.razor.cs
@@ -27,7 +27,7 @@ namespace BlazorFluentUI
         public int ColumnStartIndex { get; set; }
 
         [Parameter]
-        public IEnumerable<DetailsRowColumn<TItem>>? Columns { get; set; }
+        public IEnumerable<IDetailsRowColumn<TItem>>? Columns { get; set; }
 
         [Parameter]
         public bool Compact { get; set; }

--- a/src/BlazorFluentUI.CoreComponents/DetailsRow/IDetailsRowColumn.cs
+++ b/src/BlazorFluentUI.CoreComponents/DetailsRow/IDetailsRowColumn.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.AspNetCore.Components;
+using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+
+namespace BlazorFluentUI
+{
+
+    public interface IDetailsRowColumn<TItem>
+    {
+        string? AriaLabel { get; set; }
+        double CalculatedWidth { get; set; }
+        ColumnActionsMode ColumnActionsMode { get; set; }
+
+        Func<object, bool>? FilterPredicate { get; set; }
+        object? InternalColumnItemTemplate { get;  }
+        Func<TItem, object>? FieldSelector { get; set; }
+        Expression<Func<TItem, object>>? FieldSelectorExpression { get; set; }
+        string? FilterAriaLabel { get; set; }
+        
+        string? GroupAriaLabel { get; set; }
+        string? IconClassName { get; set; }
+        string? IconName { get; set; }
+        string? IconSrc { get; set; }
+        int Index { get; set; }
+        bool IsCollapsible { get; set; }
+        bool IsFiltered { get; set; }
+        bool IsGrouped { get; set; }
+        bool IsIconOnly { get; set; }
+        bool IsMenuOpen { get; set; }
+        bool IsMultiline { get; set; }
+        bool IsPadded { get; set; }
+        bool IsResizable { get; set; }
+        bool IsRowHeader { get; set; }
+        bool IsSorted { get; set; }
+        bool IsSortedDescending { get; set; }
+        string? Key { get; set; }
+        double MaxWidth { get; set; }
+        double MinWidth { get; set; }
+        string? Name { get; set; }
+        Action<IDetailsRowColumn<TItem>>? OnColumnClick { get; set; }
+        Action<IDetailsRowColumn<TItem>>? OnColumnContextMenu { get; set; }
+        Type? PropType { get; }
+        string? SortedAscendingAriaLabel { get; set; }
+        string? SortedDescendingAriaLabel { get; set; }
+        Type? Type { get; set; }
+        IObservable<PropertyChangedEventArgs>? WhenPropertyChanged { get; }
+
+        event PropertyChangedEventHandler? PropertyChanged;
+    }
+}

--- a/src/BlazorFluentUI.ListComponents/DetailsList/ColumnResizedArgs.cs
+++ b/src/BlazorFluentUI.ListComponents/DetailsList/ColumnResizedArgs.cs
@@ -4,9 +4,9 @@
     {
         public int ColumnIndex { get; set; }
         public double NewWidth { get; set; }
-        public DetailsRowColumn<TItem> Column { get; set; }
+        public IDetailsRowColumn<TItem> Column { get; set; }
 
-        public ColumnResizedArgs(DetailsRowColumn<TItem> column, int colIndex, double width)
+        public ColumnResizedArgs(IDetailsRowColumn<TItem> column, int colIndex, double width)
         {
             Column = column;
             ColumnIndex = colIndex;

--- a/src/BlazorFluentUI.ListComponents/DetailsList/DetailsColumn.razor.cs
+++ b/src/BlazorFluentUI.ListComponents/DetailsList/DetailsColumn.razor.cs
@@ -9,7 +9,7 @@ namespace BlazorFluentUI.Lists
     {
 
         [Parameter]
-        public DetailsRowColumn<TItem>? Column { get; set; }
+        public IDetailsRowColumn<TItem>? Column { get; set; }
 
         [Parameter]
         public RenderFragment<object>? ColumnHeaderTooltipTemplate { get; set; }
@@ -27,10 +27,10 @@ namespace BlazorFluentUI.Lists
         public bool IsDropped { get; set; }
 
         [Parameter]
-        public EventCallback<DetailsRowColumn<TItem>> OnColumnClick { get; set; }
+        public EventCallback<IDetailsRowColumn<TItem>> OnColumnClick { get; set; }
 
         [Parameter]
-        public EventCallback<DetailsRowColumn<TItem>> OnColumnContextMenu { get; set; }
+        public EventCallback<IDetailsRowColumn<TItem>> OnColumnContextMenu { get; set; }
 
         [Parameter]
         public string? ParentId { get; set; }

--- a/src/BlazorFluentUI.ListComponents/DetailsList/DetailsHeader.razor.cs
+++ b/src/BlazorFluentUI.ListComponents/DetailsList/DetailsHeader.razor.cs
@@ -40,7 +40,7 @@ namespace BlazorFluentUI.Lists
         public object? ColumnReorderProps { get; set; }
 
         [Parameter]
-        public IEnumerable<DetailsRowColumn<TItem>>? Columns { get; set; }
+        public IEnumerable<IDetailsRowColumn<TItem>>? Columns { get; set; }
 
         [Parameter]
         public RenderFragment? DetailsCheckboxTemplate { get; set; }
@@ -65,13 +65,13 @@ namespace BlazorFluentUI.Lists
 
 
         [Parameter]
-        public EventCallback<ItemContainer<DetailsRowColumn<TItem>>> OnColumnAutoResized { get; set; }
+        public EventCallback<ItemContainer<IDetailsRowColumn<TItem>>> OnColumnAutoResized { get; set; }
 
         [Parameter]
-        public EventCallback<DetailsRowColumn<TItem>> OnColumnClick { get; set; }
+        public EventCallback<IDetailsRowColumn<TItem>> OnColumnClick { get; set; }
 
         [Parameter]
-        public EventCallback<DetailsRowColumn<TItem>> OnColumnContextMenu { get; set; }
+        public EventCallback<IDetailsRowColumn<TItem>> OnColumnContextMenu { get; set; }
 
         [Parameter]
         public EventCallback<object> OnColumnIsSizingChanged { get; set; }
@@ -184,7 +184,7 @@ namespace BlazorFluentUI.Lists
         public void OnDoubleClick(int columnIndex)
         {
             //System.Diagnostics.Debug.WriteLine("DoubleClick happened.");
-            OnColumnAutoResized.InvokeAsync(new ItemContainer<DetailsRowColumn<TItem>> { Item = Columns!.ElementAt(columnIndex), Index = columnIndex });
+            OnColumnAutoResized.InvokeAsync(new ItemContainer<IDetailsRowColumn<TItem>> { Item = Columns!.ElementAt(columnIndex), Index = columnIndex });
         }
 
         private void OnSelectAllClicked(MouseEventArgs mouseEventArgs)

--- a/src/BlazorFluentUI.ListComponents/DetailsList/DetailsList.razor.cs
+++ b/src/BlazorFluentUI.ListComponents/DetailsList/DetailsList.razor.cs
@@ -15,7 +15,7 @@ namespace BlazorFluentUI.Lists
         public CheckboxVisibility CheckboxVisibility { get; set; } = CheckboxVisibility.OnHover;
 
         [Parameter]
-        public IEnumerable<DetailsRowColumn<TItem>>? Columns { get; set; }
+        public IEnumerable<IDetailsRowColumn<TItem>>? Columns { get; set; }
 
         [Parameter]
         public bool Compact { get; set; }
@@ -103,7 +103,7 @@ namespace BlazorFluentUI.Lists
         //SelectionMode _lastSelectionMode;
         Viewport? _lastViewport;
         Viewport? _viewport;
-        private IEnumerable<DetailsRowColumn<TItem?>> _adjustedColumns = Enumerable.Empty<DetailsRowColumn<TItem?>>();
+        private IEnumerable<IDetailsRowColumn<TItem?>> _adjustedColumns = Enumerable.Empty<IDetailsRowColumn<TItem?>>();
         const double MIN_COLUMN_WIDTH = 100;
 
 
@@ -155,7 +155,7 @@ namespace BlazorFluentUI.Lists
                     parameters.GetValueOrDefault<DetailsListLayoutMode>("LayoutMode"),
                     parameters.GetValueOrDefault<SelectionMode>("SelectionMode"),
                     parameters.GetValueOrDefault<CheckboxVisibility>("CheckboxVisibility"),
-                    parameters.GetValueOrDefault<IEnumerable<DetailsRowColumn<TItem>>>("Columns")!,
+                    parameters.GetValueOrDefault<IEnumerable<IDetailsRowColumn<TItem>>>("Columns")!,
                     true
                     );
             }
@@ -265,26 +265,26 @@ namespace BlazorFluentUI.Lists
             }
         }
 
-        private void AdjustColumns(IEnumerable<TItem?> newItems, DetailsListLayoutMode newLayoutMode, SelectionMode newSelectionMode, CheckboxVisibility newCheckboxVisibility, IEnumerable<DetailsRowColumn<TItem?>> newColumns, bool forceUpdate, int resizingColumnIndex = -1)
+        private void AdjustColumns(IEnumerable<TItem?> newItems, DetailsListLayoutMode newLayoutMode, SelectionMode newSelectionMode, CheckboxVisibility newCheckboxVisibility, IEnumerable<IDetailsRowColumn<TItem?>> newColumns, bool forceUpdate, int resizingColumnIndex = -1)
         {
             _adjustedColumns = GetAdjustedColumns(newItems, newLayoutMode, newSelectionMode, newCheckboxVisibility, newColumns, forceUpdate, resizingColumnIndex);
         }
 
-        private IEnumerable<DetailsRowColumn<TItem?>> GetAdjustedColumns(IEnumerable<TItem?> newItems, DetailsListLayoutMode newLayoutMode, SelectionMode newSelectionMode, CheckboxVisibility newCheckboxVisibility, IEnumerable<DetailsRowColumn<TItem?>> newColumns, bool forceUpdate, int resizingColumnIndex)
+        private IEnumerable<IDetailsRowColumn<TItem?>> GetAdjustedColumns(IEnumerable<TItem?> newItems, DetailsListLayoutMode newLayoutMode, SelectionMode newSelectionMode, CheckboxVisibility newCheckboxVisibility, IEnumerable<IDetailsRowColumn<TItem?>> newColumns, bool forceUpdate, int resizingColumnIndex)
         {
 
             if (!forceUpdate && _lastViewport?.Width == _viewport?.Width && SelectionMode == newSelectionMode && (Columns == null || newColumns == Columns))
-                return Enumerable.Empty<DetailsRowColumn<TItem?>>();
+                return Enumerable.Empty<IDetailsRowColumn<TItem?>>();
 
             // skipping default column builder... user must provide columns always
 
-            IEnumerable<DetailsRowColumn<TItem?>> adjustedColumns;
+            IEnumerable<IDetailsRowColumn<TItem?>> adjustedColumns;
 
             if (LayoutMode == DetailsListLayoutMode.FixedColumns)
             {
                 adjustedColumns = DetailsList<TItem?>.GetFixedColumns(newColumns);
 
-                foreach (DetailsRowColumn<TItem?> col in adjustedColumns)
+                foreach (IDetailsRowColumn<TItem?> col in adjustedColumns)
                     _columnOverrides[col.Key!] = col.CalculatedWidth;
             }
             else
@@ -298,7 +298,7 @@ namespace BlazorFluentUI.Lists
                     adjustedColumns = GetJustifiedColumns(newColumns, newCheckboxVisibility, newSelectionMode, _viewport!.Width, resizingColumnIndex);
                 }
 
-                foreach (DetailsRowColumn<TItem?> col in adjustedColumns)
+                foreach (IDetailsRowColumn<TItem?> col in adjustedColumns)
                 {
                     _columnOverrides[col.Key!] = col.CalculatedWidth;
                 }
@@ -309,19 +309,19 @@ namespace BlazorFluentUI.Lists
             return adjustedColumns;
         }
 
-        private static IEnumerable<DetailsRowColumn<TItem?>> GetFixedColumns(IEnumerable<DetailsRowColumn<TItem?>> newColumns)
+        private static IEnumerable<IDetailsRowColumn<TItem?>> GetFixedColumns(IEnumerable<IDetailsRowColumn<TItem?>> newColumns)
         {
-            foreach (DetailsRowColumn<TItem?> col in newColumns)
+            foreach (IDetailsRowColumn<TItem?> col in newColumns)
             {
                 col.CalculatedWidth = !double.IsNaN(col.MaxWidth) ? col.MaxWidth : (!double.IsNaN(col.MinWidth) ? col.MinWidth : MIN_COLUMN_WIDTH);
             }
             return newColumns;
         }
 
-        private IEnumerable<DetailsRowColumn<TItem?>> GetJustifiedColumnsAfterResize(IEnumerable<DetailsRowColumn<TItem?>> newColumns, CheckboxVisibility newCheckboxVisibility, SelectionMode newSelectionMode, double viewportWidth, int resizingColumnIndex)
+        private IEnumerable<IDetailsRowColumn<TItem?>> GetJustifiedColumnsAfterResize(IEnumerable<IDetailsRowColumn<TItem?>> newColumns, CheckboxVisibility newCheckboxVisibility, SelectionMode newSelectionMode, double viewportWidth, int resizingColumnIndex)
         {
-            IEnumerable<DetailsRowColumn<TItem?>> fixedColumns = newColumns.Take(resizingColumnIndex);
-            foreach (DetailsRowColumn<TItem?> col in fixedColumns)
+            IEnumerable<IDetailsRowColumn<TItem?>> fixedColumns = newColumns.Take(resizingColumnIndex);
+            foreach (IDetailsRowColumn<TItem?> col in fixedColumns)
             {
                 if (_columnOverrides.TryGetValue(col.Key!, out double overridenWidth))
                     col.CalculatedWidth = overridenWidth;
@@ -329,25 +329,25 @@ namespace BlazorFluentUI.Lists
                     col.CalculatedWidth = double.NaN;
             }
 
-            double fixedWidth = fixedColumns.Aggregate<DetailsRowColumn<TItem?>, double, double>(0, (total, column) => total + DetailsList<TItem?>.GetPaddedWidth(column), x => x);
+            double fixedWidth = fixedColumns.Aggregate<IDetailsRowColumn<TItem?>, double, double>(0, (total, column) => total + DetailsList<TItem?>.GetPaddedWidth(column), x => x);
 
-            IEnumerable<DetailsRowColumn<TItem?>>? remainingColumns = newColumns.Skip(resizingColumnIndex).Take(newColumns.Count() - resizingColumnIndex);
+            IEnumerable<IDetailsRowColumn<TItem?>>? remainingColumns = newColumns.Skip(resizingColumnIndex).Take(newColumns.Count() - resizingColumnIndex);
             double remainingWidth = viewportWidth - fixedWidth;
 
-            IEnumerable<DetailsRowColumn<TItem?>>? adjustedColumns = GetJustifiedColumns(remainingColumns, newCheckboxVisibility, newSelectionMode, remainingWidth, resizingColumnIndex);
+            IEnumerable<IDetailsRowColumn<TItem?>>? adjustedColumns = GetJustifiedColumns(remainingColumns, newCheckboxVisibility, newSelectionMode, remainingWidth, resizingColumnIndex);
 
             return Enumerable.Concat(fixedColumns, adjustedColumns);
         }
 
-        private IEnumerable<DetailsRowColumn<TItem?>> GetJustifiedColumns(IEnumerable<DetailsRowColumn<TItem?>> newColumns, CheckboxVisibility newCheckboxVisibility, SelectionMode newSelectionMode, double viewportWidth, int resizingColumnIndex)
+        private IEnumerable<IDetailsRowColumn<TItem?>> GetJustifiedColumns(IEnumerable<IDetailsRowColumn<TItem?>> newColumns, CheckboxVisibility newCheckboxVisibility, SelectionMode newSelectionMode, double viewportWidth, int resizingColumnIndex)
         {
             int rowCheckWidth = newSelectionMode != SelectionMode.None && newCheckboxVisibility != CheckboxVisibility.Hidden ? 48 : 0;  //DetailsRowCheckbox width
             int groupExpandedWidth = 0; //skipping this for now.
             double totalWidth = 0;
             double availableWidth = viewportWidth - (rowCheckWidth + groupExpandedWidth);
 
-            System.Collections.Generic.List<DetailsRowColumn<TItem?>> adjustedColumns = new();
-            foreach (DetailsRowColumn<TItem?> col in newColumns)
+            System.Collections.Generic.List<IDetailsRowColumn<TItem?>> adjustedColumns = new();
+            foreach (IDetailsRowColumn<TItem?> col in newColumns)
             {
                 adjustedColumns.Add(col);
                 col.CalculatedWidth = !double.IsNaN(col.MinWidth) ? col.MinWidth : 100;
@@ -362,7 +362,7 @@ namespace BlazorFluentUI.Lists
             // Shrink or remove collapsable columns.
             while (lastIndex > 0 && totalWidth > availableWidth)
             {
-                DetailsRowColumn<TItem?> col = adjustedColumns.ElementAt(lastIndex);
+                IDetailsRowColumn<TItem?> col = adjustedColumns.ElementAt(lastIndex);
                 double minWidth = !double.IsNaN(col.MinWidth) ? col.MinWidth : 100;
                 double overflowWidth = totalWidth - availableWidth;
 
@@ -383,7 +383,7 @@ namespace BlazorFluentUI.Lists
             //Then expand columns starting at the beginning, until we've filled the width.
             for (int i = 0; i < adjustedColumns.Count && totalWidth < availableWidth; i++)
             {
-                DetailsRowColumn<TItem?> col = adjustedColumns[i];
+                IDetailsRowColumn<TItem?> col = adjustedColumns[i];
                 bool isLast = i == adjustedColumns.Count - 1;
                 bool hasOverrides = _columnOverrides.TryGetValue(col.Key!, out _);
                 if (hasOverrides && !isLast)
@@ -407,7 +407,7 @@ namespace BlazorFluentUI.Lists
             return adjustedColumns;
         }
 
-        private static double GetPaddedWidth(DetailsRowColumn<TItem?> column)
+        private static double GetPaddedWidth(IDetailsRowColumn<TItem?> column)
         {
             return column.CalculatedWidth +
                     DetailsRow<TItem>.CELL_LEFT_PADDING +
@@ -423,7 +423,7 @@ namespace BlazorFluentUI.Lists
             AdjustColumns(ItemsSource, LayoutMode, SelectionMode, CheckboxVisibility, Columns!, true, columnResizedArgs.ColumnIndex);
         }
 
-        private static void OnColumnAutoResized(ItemContainer<DetailsRowColumn<TItem>> itemContainer)
+        private static void OnColumnAutoResized(ItemContainer<IDetailsRowColumn<TItem>> itemContainer)
         {
             // TO-DO - will require measuring row cells, jsinterop
         }

--- a/src/BlazorFluentUI.ListComponents/GroupedList/GroupedListAuto.razor.cs
+++ b/src/BlazorFluentUI.ListComponents/GroupedList/GroupedListAuto.razor.cs
@@ -46,13 +46,13 @@ namespace BlazorFluentUI.Lists
         [CascadingParameter]
         public SelectionZone<TItem>? SelectionZone { get; set; }
 
-        private IEnumerable<DetailsRowColumn<TItem>>? _columns;
+        private IEnumerable<IDetailsRowColumn<TItem>>? _columns;
 
         /// <summary>
         /// This is intended to be populated only when GroupedList is rendered under DetailsList.
         /// </summary>
         [Parameter]
-        public IEnumerable<DetailsRowColumn<TItem>>? Columns { get => _columns; set { if (_columns == value) return; else { _columns = value; OnPropertyChanged(); } } }
+        public IEnumerable<IDetailsRowColumn<TItem>>? Columns { get => _columns; set { if (_columns == value) return; else { _columns = value; OnPropertyChanged(); } } }
 
 
         [Parameter]


### PR DESCRIPTION
Not sure if this is ready to go.  I changed a lot of things and I'm not sure I didn't break something.  (I realize that DetailsList wasn't perfect before anyways.)

Main Changes:

1.  `IDetailsRowColumn` interface instead of `DetailsRowColumn` for all parameters

2.  I removed the generic property for the FilterExpression on the IDetailsRowColumn.  Now it is a `Func<object,bool>`.  This makes it easier to work with the new interface.

3.   I'm unsure about this one.  There are still two versions of DetailsRowColumn.  
     -  One has an overload that creates an `Expression<Func<TItem,object>>` that can be used with the new `DynamicAccessor<TItem>`.  This is useful for when you want to bind a single property and want a value-type to have two-way binding.  This is useful when you have a simple `List<string>` for example.
     - The other has an overload that just creates a `Func<TItem,object>`.  You can **still** use this for two-way binding of value type objects, BUT you'll have to bind an object and reference the property of the object inside the ColumnItemTemplate.

If anyone want to check this out and make suggestions, I'm up for it before we merge anything...