### PR TITLE
Attempt to fix thrown errors when second DatePicker is clicked immedi…

### DIFF
--- a/src/BlazorFluentUI.CoreComponents/BaseComponent/Layer/Layer.cs
+++ b/src/BlazorFluentUI.CoreComponents/BaseComponent/Layer/Layer.cs
@@ -104,7 +104,7 @@ namespace BlazorFluentUI
                     }
                 }
 
-                await baseModule!.InvokeVoidAsync("addOrUpdateVirtualParent", _element);
+                await baseModule!.InvokeVoidAsync("addOrUpdateVirtualParent", cancellationTokenSource.Token, _element);
             }
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -113,6 +113,7 @@ namespace BlazorFluentUI
         {
             if (LayerHost != null)
                 await LayerHost.RemoveHostedContentAsync(id)!;
+            cancellationTokenSource.Cancel();
             addedToHost = false;
             if (baseModule != null)
                 await baseModule.DisposeAsync();

--- a/src/BlazorFluentUI.CoreComponents/FocusTrapZone/FocusTrapZone.razor.cs
+++ b/src/BlazorFluentUI.CoreComponents/FocusTrapZone/FocusTrapZone.razor.cs
@@ -60,8 +60,12 @@ namespace BlazorFluentUI
         {
             if (_id != -1)
             {
-                FocusTrapZoneProps? props = new(this, _firstBumper, _lastBumper);
-                await scriptModule!.InvokeVoidAsync("updateProps", _id, props);
+                try
+                {
+                    FocusTrapZoneProps? props = new(this, _firstBumper, _lastBumper);
+                    await scriptModule!.InvokeVoidAsync("updateProps", _id, props);
+                }
+                catch { }
             }
 
             await base.OnParametersSetAsync();
@@ -84,12 +88,17 @@ namespace BlazorFluentUI
             FocusTrapZoneProps? props = new(this, _firstBumper, _lastBumper);
 
             selfReference = DotNetObjectReference.Create(this);
-            _id = await scriptModule!.InvokeAsync<int>("register", props, selfReference);
+            try
+            {
+                _id = await scriptModule!.InvokeAsync<int>("register", cancellationTokenSource.Token, props, selfReference);
+            }
+            catch { }
         }
 
 
         public override async ValueTask DisposeAsync()
         {
+            cancellationTokenSource.Cancel();
             if (_id != -1 && scriptModule != null)
             {
                 await scriptModule.InvokeVoidAsync("unregister", _id);

--- a/src/BlazorFluentUI.CoreComponents/FocusTrapZone/FocusTrapZoneProps.cs
+++ b/src/BlazorFluentUI.CoreComponents/FocusTrapZone/FocusTrapZoneProps.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 
 namespace BlazorFluentUI
@@ -55,6 +56,7 @@ namespace BlazorFluentUI
             RootElement = focusTrapZone.RootElementReference;
             FirstBumper = firstBumper;
             LastBumper = lastBumper;
+            
         }
     }
 }

--- a/src/BlazorFluentUI.CoreComponents/wwwroot/baseComponent.js
+++ b/src/BlazorFluentUI.CoreComponents/wwwroot/baseComponent.js
@@ -170,7 +170,7 @@ export function getElementId(element) {
     }
     return null;
 }
-var eventRegister = {};
+var eventRegister = new Map();
 var eventElementRegister = {};
 /* Function for Dropdown, but could apply to focusing on any element after onkeydown outside of list containing is-element-focusable items */
 export function registerKeyEventsForList(element) {
@@ -218,32 +218,32 @@ export function deregisterKeyEventsForList(guid) {
 }
 export function registerWindowKeyDownEvent(dotnetRef, keyCode, functionName) {
     var guid = Guid.newGuid();
-    eventRegister[guid] = (ev) => {
+    eventRegister.set(guid, (ev) => {
         if (ev.code == keyCode) {
             ev.preventDefault();
             ev.stopPropagation();
             dotnetRef.invokeMethodAsync(functionName, ev.code);
         }
-    };
-    window.addEventListener("keydown", eventRegister[guid]);
+    });
+    window.addEventListener("keydown", eventRegister.get(guid));
     return guid;
 }
 export function deregisterWindowKeyDownEvent(guid) {
-    var func = eventRegister[guid];
+    var func = eventRegister.get(guid);
     window.removeEventListener("keydown", func);
-    eventRegister[guid] = null;
+    eventRegister.delete(guid);
 }
 export function registerResizeEvent(dotnetRef, functionName, guid) {
     var async = new Async(this);
-    eventRegister[guid] = async.debounce((ev) => {
+    eventRegister.set(guid, async.debounce((ev) => {
         dotnetRef.invokeMethodAsync(functionName, window.innerWidth, innerHeight);
-    }, 100, { leading: true });
-    window.addEventListener("resize", eventRegister[guid]);
+    }, 100, { leading: true }));
+    window.addEventListener("resize", eventRegister.get(guid));
 }
 export function deregisterResizeEvent(guid) {
-    var func = eventRegister[guid];
+    var func = eventRegister.get(guid);
     window.removeEventListener("resize", func);
-    eventRegister[guid] = null;
+    eventRegister.delete(guid);
 }
 class Guid {
     static newGuid() {

--- a/src/BlazorFluentUI.CoreComponents/wwwroot/baseComponent.ts
+++ b/src/BlazorFluentUI.CoreComponents/wwwroot/baseComponent.ts
@@ -240,7 +240,7 @@ interface MapSimple<T> {
     [K: string]: T;
 }
 
-var eventRegister: MapSimple<(ev: UIEvent) => void> = {};
+var eventRegister: Map<string, (ev: UIEvent) => void> = new Map <string, (ev: UIEvent) => void>();
 
 var eventElementRegister: MapSimple<[HTMLElement, (ev: UIEvent) => void]> = {};
 
@@ -290,35 +290,39 @@ export function deregisterKeyEventsForList(guid: number) {
 
 export function registerWindowKeyDownEvent(dotnetRef: DotNetReferenceType, keyCode: string, functionName: string): string {
     var guid = Guid.newGuid();
-    eventRegister[guid] = (ev: KeyboardEvent) => {
+    eventRegister.set(guid, (ev: KeyboardEvent) => {
         if (ev.code == keyCode) {
             ev.preventDefault();
             ev.stopPropagation();
             dotnetRef.invokeMethodAsync(functionName, ev.code);
         }
-    };
-    window.addEventListener("keydown", eventRegister[guid]);
+    });
+    window.addEventListener("keydown", eventRegister.get(guid));
     return guid;
 }
 
-export function deregisterWindowKeyDownEvent(guid: number) {
-    var func = eventRegister[guid];
+export function deregisterWindowKeyDownEvent(guid: string) {
+    var func = eventRegister.get(guid);
     window.removeEventListener("keydown", func);
-    eventRegister[guid] = null;
+    eventRegister.delete(guid);
 }
 
 export function registerResizeEvent(dotnetRef: DotNetReferenceType, functionName: string, guid: string) {
     var async = new Async(this);
-    eventRegister[guid] = async.debounce((ev: UIEvent) => {
-        dotnetRef.invokeMethodAsync(functionName, window.innerWidth, innerHeight);
-    }, 100, { leading: true });
-    window.addEventListener("resize", eventRegister[guid]);
+    eventRegister.set(
+        guid,
+        async.debounce((ev: UIEvent) => {
+            dotnetRef.invokeMethodAsync(functionName, window.innerWidth, innerHeight);
+        }, 100, { leading: true })
+    );
+    window.addEventListener("resize", eventRegister.get(guid))
+
 }
 
-export function deregisterResizeEvent(guid: number) {
-    var func = eventRegister[guid];
+export function deregisterResizeEvent(guid: string) {
+    var func = eventRegister.get(guid);
     window.removeEventListener("resize", func);
-    eventRegister[guid] = null;
+    eventRegister.delete(guid);
 }
 
 class Guid {

--- a/src/BlazorFluentUI.CoreComponents/wwwroot/focusTrapZone.js
+++ b/src/BlazorFluentUI.CoreComponents/wwwroot/focusTrapZone.js
@@ -83,8 +83,8 @@ class FocusTrapZoneInternal {
             }
             else if (lastActiveFocusTrap._props.rootElement &&
                 lastActiveFocusTrap._props.rootElement.hasAttribute(HIDDEN_FROM_ACC_TREE)) {
-                lastActiveFocusTrap._props.rootElement.removeAttribute(HIDDEN_FROM_ACC_TREE);
-                lastActiveFocusTrap._props.rootElement.removeAttribute('aria-hidden');
+                lastActiveFocusTrap._props.rootElement?.removeAttribute(HIDDEN_FROM_ACC_TREE);
+                lastActiveFocusTrap._props.rootElement?.removeAttribute('aria-hidden');
             }
         };
         this._findElementAndFocusAsync = () => {
@@ -203,18 +203,18 @@ class FocusTrapZoneInternal {
         };
         this._props = focusTrapZoneProps;
         this._dotNetRef = dotNetRef;
-        this._props.rootElement.addEventListener("focus", this._onRootFocus, false);
-        this._props.rootElement.addEventListener("blur", this._onRootBlur, false);
-        this._props.firstBumper.addEventListener("focus", this._onFirstBumperFocus, false);
-        this._props.lastBumper.addEventListener("focus", this._onLastBumperFocus, false);
+        this._props.rootElement?.addEventListener("focus", this._onRootFocus, false);
+        this._props.rootElement?.addEventListener("blur", this._onRootBlur, false);
+        this._props.firstBumper?.addEventListener("focus", this._onFirstBumperFocus, false);
+        this._props.lastBumper?.addEventListener("focus", this._onLastBumperFocus, false);
         //this._bringFocusIntoZone();
     }
     unRegister() {
         const activeElement = document.activeElement;
-        this._props.rootElement.removeEventListener("focus", this._onRootFocus, false);
-        this._props.rootElement.removeEventListener("blur", this._onRootBlur, false);
-        this._props.firstBumper.removeEventListener("focus", this._onFirstBumperFocus, false);
-        this._props.lastBumper.removeEventListener("focus", this._onLastBumperFocus, false);
+        this._props.rootElement?.removeEventListener("focus", this._onRootFocus, false);
+        this._props.rootElement?.removeEventListener("blur", this._onRootBlur, false);
+        this._props.firstBumper?.removeEventListener("focus", this._onFirstBumperFocus, false);
+        this._props.lastBumper?.removeEventListener("focus", this._onLastBumperFocus, false);
         if (!this._props.disabled ||
             this._props.forceFocusInsideTrapOnOutsideFocus ||
             // @ts-ignore

--- a/src/BlazorFluentUI.CoreComponents/wwwroot/focusTrapZone.ts
+++ b/src/BlazorFluentUI.CoreComponents/wwwroot/focusTrapZone.ts
@@ -38,11 +38,11 @@ class FocusTrapZoneInternal {
         this._props = focusTrapZoneProps;
         this._dotNetRef = dotNetRef;
 
-        this._props.rootElement.addEventListener("focus", this._onRootFocus, false);
-        this._props.rootElement.addEventListener("blur", this._onRootBlur, false);
+        this._props.rootElement?.addEventListener("focus", this._onRootFocus, false);
+        this._props.rootElement?.addEventListener("blur", this._onRootBlur, false);
 
-        this._props.firstBumper.addEventListener("focus", this._onFirstBumperFocus, false);
-        this._props.lastBumper.addEventListener("focus", this._onLastBumperFocus, false);
+        this._props.firstBumper?.addEventListener("focus", this._onFirstBumperFocus, false);
+        this._props.lastBumper?.addEventListener("focus", this._onLastBumperFocus, false);
 
         //this._bringFocusIntoZone();
     }
@@ -50,11 +50,11 @@ class FocusTrapZoneInternal {
     public unRegister(): void {
         const activeElement = document.activeElement as HTMLElement;
 
-        this._props.rootElement.removeEventListener("focus", this._onRootFocus, false);
-        this._props.rootElement.removeEventListener("blur", this._onRootBlur, false);
+        this._props.rootElement?.removeEventListener("focus", this._onRootFocus, false);
+        this._props.rootElement?.removeEventListener("blur", this._onRootBlur, false);
 
-        this._props.firstBumper.removeEventListener("focus", this._onFirstBumperFocus, false);
-        this._props.lastBumper.removeEventListener("focus", this._onLastBumperFocus, false);
+        this._props.firstBumper?.removeEventListener("focus", this._onFirstBumperFocus, false);
+        this._props.lastBumper?.removeEventListener("focus", this._onLastBumperFocus, false);
 
         if (
             !this._props.disabled ||
@@ -235,8 +235,8 @@ class FocusTrapZoneInternal {
             lastActiveFocusTrap._props.rootElement &&
             lastActiveFocusTrap._props.rootElement.hasAttribute(HIDDEN_FROM_ACC_TREE)
         ) {
-            lastActiveFocusTrap._props.rootElement.removeAttribute(HIDDEN_FROM_ACC_TREE);
-            lastActiveFocusTrap._props.rootElement.removeAttribute('aria-hidden');
+            lastActiveFocusTrap._props.rootElement?.removeAttribute(HIDDEN_FROM_ACC_TREE);
+            lastActiveFocusTrap._props.rootElement?.removeAttribute('aria-hidden');
         }
     };
 


### PR DESCRIPTION
…ately after opening a first one.

Major change (non-breaking):

I added a `CancellationTokenSource` to the FluentUIComponentBase.  The intention is to be able to insert the `CancellationToken` from this source into any jsinterop calls that could take place **after** the component is disposed.  There is an overload in the InvokeAsync method that takes this token.  All we need to do is to apply a try..catch(TaskCancelationException ex) around that portion of the code.  Also, if DisposeAsync is overridden for that component, we need to add a `cancellationTokenSource.Cancel()` somewhere appropriate.

This _has_ solved the errors in #301.   (And shown there's something else wrong with how callouts get dismissed... but that's a separate issue.)  #301 was crashing the entire app so it's a big problem.

If this addition seems reasonable, let's merge it, but I wanted to make sure you had a chance to object because I'm making changes to the base class.