### PR TITLE
Check cancellation after JS import (fixes #325)

### DIFF
--- a/src/BlazorFluentUI.CoreComponents/BaseComponent/FluentUIComponentBase.cs
+++ b/src/BlazorFluentUI.CoreComponents/BaseComponent/FluentUIComponentBase.cs
@@ -66,11 +66,13 @@ namespace BlazorFluentUI
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-
             try
             {
                 if (baseModule == null)
-                    baseModule = await JSRuntime!.InvokeAsync<IJSObjectReference>("import", cancellationTokenSource.Token, BasePath);
+                    baseModule = await JSRuntime!.InvokeAsync<IJSObjectReference>("import", BasePath);
+
+                if (cancellationTokenSource.Token.IsCancellationRequested)
+                    throw new TaskCanceledException();
 
                 if (!ScopedStatics!.FocusRectsInitialized)
                 {


### PR DESCRIPTION
See #325 for the issue being addressed.

This change prevents the JS interop call to `import` from being cancelled as it was leading to `JsonException`s.