### PR TITLE
Fix calendar dayCell not adhering to theme.

### DIFF
--- a/src/BlazorFluentUI.CoreComponents/Calendar/Calendar.razor.css
+++ b/src/BlazorFluentUI.CoreComponents/Calendar/Calendar.razor.css
@@ -151,7 +151,7 @@
     line-height: 28px;
     font-size: 12px;
     font-weight: 400;
-    color: rgb(50, 49, 48);
+    color: var(--palette-NeutralPrimary);
     cursor: pointer;
     position: relative;
 }


### PR DESCRIPTION
The caledar's dayCell has a hard-coded colour which causes accessibility issues when using a dark theme. This changes it to use the same palette colour as the rest of the calendar's text.